### PR TITLE
update grpc/grpc in composer.lock to remove dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ebda4b955a5b5cbe8e1a414acc1b371",
+    "content-hash": "6f59e2b16eed82870c2a3229fe35412e",
     "packages": [
         {
             "name": "phpunit/php-timer",
@@ -58,6 +58,46 @@
     ],
     "packages-dev": [
         {
+            "name": "bigcommerce/grpc-php",
+            "version": "dev-bc-1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bigcommerce/grpc-php.git",
+                "reference": "d74da06c7bc06c743169bfc394ec347fd9e85c26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bigcommerce/grpc-php/zipball/d74da06c7bc06c743169bfc394ec347fd9e85c26",
+                "reference": "d74da06c7bc06c743169bfc394ec347fd9e85c26",
+                "shasum": ""
+            },
+            "require": {
+                "google/protobuf": "^v3.1.0",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "google/auth": "v0.9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\": "src/lib/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "gRPC library for PHP",
+            "homepage": "http://grpc.io",
+            "keywords": [
+                "rpc"
+            ],
+            "support": {
+                "source": "https://github.com/bigcommerce/grpc-php/tree/bc-1.3.2"
+            },
+            "time": "2017-09-14T18:06:44+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "dev-master",
             "source": {
@@ -109,7 +149,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-02-16 16:15:51"
+            "time": "2017-02-16T16:15:51+00:00"
         },
         {
             "name": "google/protobuf",
@@ -150,45 +190,7 @@
             "keywords": [
                 "proto"
             ],
-            "time": "2017-05-19 18:22:45"
-        },
-        {
-            "name": "grpc/grpc",
-            "version": "v1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/grpc/grpc.git",
-                "reference": "c80d3321d0f77bef8cfff8b32490a07c1e90a5ad"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc/zipball/c80d3321d0f77bef8cfff8b32490a07c1e90a5ad",
-                "reference": "c80d3321d0f77bef8cfff8b32490a07c1e90a5ad",
-                "shasum": ""
-            },
-            "require": {
-                "google/protobuf": "^v3.1.0",
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "google/auth": "v0.9"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Grpc\\": "src/php/lib/Grpc/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "gRPC library for PHP",
-            "homepage": "http://grpc.io",
-            "keywords": [
-                "rpc"
-            ],
-            "time": "2017-05-11T17:18:56+00:00"
+            "time": "2017-05-19T18:22:45+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -285,7 +287,7 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-04-07 07:07:10"
+            "time": "2017-04-07T07:07:10+00:00"
         },
         {
             "name": "phar-io/version",
@@ -386,7 +388,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-04-30 11:58:12"
+            "time": "2017-04-30T11:58:12+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -541,7 +543,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-05-17 11:25:27"
+            "time": "2017-05-17T11:25:27+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -652,7 +654,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -742,7 +744,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-03-07 07:36:57"
+            "time": "2017-03-07T07:36:57+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -826,7 +828,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-05-19 03:58:51"
+            "time": "2017-05-19T03:58:51+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -885,7 +887,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-04-01 10:07:28"
+            "time": "2017-04-01T10:07:28+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -930,7 +932,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04 10:23:55"
+            "time": "2017-03-04T10:23:55+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -994,7 +996,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-05-19 04:08:27"
+            "time": "2017-05-19T04:08:27+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1046,7 +1048,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-21 05:03:06"
+            "time": "2017-05-21T05:03:06+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1096,7 +1098,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-05-18 10:10:00"
+            "time": "2017-05-18T10:10:00+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1163,7 +1165,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03 13:19:02"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1214,7 +1216,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27 15:39:26"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1261,7 +1263,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-03-12 15:17:29"
+            "time": "2017-03-12T15:17:29+00:00"
         },
         {
             "name": "sebastian/object-reflector",
@@ -1306,7 +1308,7 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29 09:07:27"
+            "time": "2017-03-29T09:07:27+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1359,7 +1361,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-07 15:09:59"
+            "time": "2017-03-07T15:09:59+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1401,7 +1403,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2016-10-03 07:43:09"
+            "time": "2016-10-03T07:43:09+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1444,7 +1446,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1534,12 +1536,13 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:41"
+            "time": "2016-11-23T20:04:41+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "bigcommerce/grpc-php": 20,
         "phpunit/php-code-coverage": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
Remove grpc/grpc from the lockfile as this has been replaced but is not explicitly removed without running update on the package.

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 1 install, 0 updates, 1 removal
  - Removing grpc/grpc (v1.3.2)
  - Installing bigcommerce/grpc-php (dev-bc-1.3.2 d74da06): Cloning d74da06c7b from cache
Writing lock file
Generating autoload files
```

ping @bc-services @precariouspanther @PascalZajac @chrisboulton