### PR TITLE
Bump grpc-php to v1.3.2-p1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "phpunit/php-timer": "1.0.*"
   },
   "require-dev": {
-    "bigcommerce/grpc-php": "dev-bc-1.3.2",
+    "bigcommerce/grpc-php": "1.3.2-p1",
     "phpunit/phpunit": "6.1.*",
     "phpunit/php-code-coverage": "^5.2@dev"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f59e2b16eed82870c2a3229fe35412e",
+    "content-hash": "5f888eb47a2a7d7a262b610ce8459628",
     "packages": [
         {
             "name": "phpunit/php-timer",
@@ -59,16 +59,16 @@
     "packages-dev": [
         {
             "name": "bigcommerce/grpc-php",
-            "version": "dev-bc-1.3.2",
+            "version": "1.3.2-p1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bigcommerce/grpc-php.git",
-                "reference": "19003eafaef5428b3119de219b53bf66658a6c87"
+                "reference": "0bba049900be583718ce87e4bff5997268b3b533"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bigcommerce/grpc-php/zipball/19003eafaef5428b3119de219b53bf66658a6c87",
-                "reference": "19003eafaef5428b3119de219b53bf66658a6c87",
+                "url": "https://api.github.com/repos/bigcommerce/grpc-php/zipball/0bba049900be583718ce87e4bff5997268b3b533",
+                "reference": "0bba049900be583718ce87e4bff5997268b3b533",
                 "shasum": ""
             },
             "require": {
@@ -93,9 +93,9 @@
                 "rpc"
             ],
             "support": {
-                "source": "https://github.com/bigcommerce/grpc-php/tree/bc-1.3.2"
+                "source": "https://github.com/bigcommerce/grpc-php/tree/v1.3.2-p1"
             },
-            "time": "2017-10-19T08:20:04+00:00"
+            "time": "2017-10-19T09:52:09+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1542,7 +1542,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "bigcommerce/grpc-php": 20,
         "phpunit/php-code-coverage": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
We should be using tags, not branches. I've also moved `grpc-php` into an actual library dependency because that's what it is -- it's not a development dependency.