### PR TITLE
Use grpc/grpc-php 1.9.* instead of bigcommerce/grpc-php 1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ up fast and efficiently at scale. Some of its features include:
 preserving gRPC BadStatus codes
 * Client execution timings in responses
 
-grphp currently has active support for gRPC 1.3.2, and requires PHP 5.5+ or 7.0+ to run. gRPC 1.4 is not yet supported.
+grphp currently has active support for gRPC 1.9.0, and requires PHP 5.5+ or 7.0+ to run.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,16 @@
   "type": "library",
   "license": "MIT",
   "repositories": [
-    { "type": "vcs", "url": "https://github.com/bigcommerce/grpc-php" }
+    { "type": "vcs", "url": "https://github.com/grpc/grpc-php" }
   ],
   "require": {
-    "phpunit/php-timer": "1.0.*"
+    "phpunit/php-timer": "1.0.*",
+    "grpc/grpc": "1.9.*",
+    "google/protobuf": "3.5.*"
   },
   "require-dev": {
     "phpunit/phpunit": "6.1.*",
-    "phpunit/php-code-coverage": "^5.2@dev",
-    "bigcommerce/grpc-php": "1.3.2-p1"
+    "phpunit/php-code-coverage": "^5.2@dev"
   },
   "autoload": {
     "psr-4": { "": "src/"}

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,92 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff7937423bae95973c8cc06b853bc0ac",
+    "content-hash": "3274b243a174728dceac82649c453476",
     "packages": [
+        {
+            "name": "google/protobuf",
+            "version": "v3.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/google/protobuf.git",
+                "reference": "b5fbb742af122b565925987e65c08957739976a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/google/protobuf/zipball/b5fbb742af122b565925987e65c08957739976a7",
+                "reference": "b5fbb742af122b565925987e65c08957739976a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Need to support JSON deserialization"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Protobuf\\": "php/src/Google/Protobuf",
+                    "GPBMetadata\\Google\\Protobuf\\": "php/src/GPBMetadata/Google/Protobuf"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "proto library for PHP",
+            "homepage": "https://developers.google.com/protocol-buffers/",
+            "keywords": [
+                "proto"
+            ],
+            "time": "2018-03-06T03:54:18+00:00"
+        },
+        {
+            "name": "grpc/grpc",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grpc/grpc-php.git",
+                "reference": "a502df7fac0b392dde13ddf157062b5184d0688e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/a502df7fac0b392dde13ddf157062b5184d0688e",
+                "reference": "a502df7fac0b392dde13ddf157062b5184d0688e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "google/auth": "v0.9"
+            },
+            "suggest": {
+                "ext-protobuf": "For better performance, install the protobuf C extension.",
+                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\": "src/lib/"
+                }
+            },
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "gRPC library for PHP",
+            "homepage": "https://grpc.io",
+            "keywords": [
+                "rpc"
+            ],
+            "support": {
+                "source": "https://github.com/grpc/grpc-php/tree/v1.9.0"
+            },
+            "time": "2018-01-24T21:48:21+00:00"
+        },
         {
             "name": "phpunit/php-timer",
             "version": "1.0.9",
@@ -57,46 +141,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "bigcommerce/grpc-php",
-            "version": "1.3.2-p1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bigcommerce/grpc-php.git",
-                "reference": "0bba049900be583718ce87e4bff5997268b3b533"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bigcommerce/grpc-php/zipball/0bba049900be583718ce87e4bff5997268b3b533",
-                "reference": "0bba049900be583718ce87e4bff5997268b3b533",
-                "shasum": ""
-            },
-            "require": {
-                "google/protobuf": "^v3.1.0",
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "google/auth": "v0.9"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Grpc\\": "src/lib/"
-                }
-            },
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "gRPC library for PHP",
-            "homepage": "http://grpc.io",
-            "keywords": [
-                "rpc"
-            ],
-            "support": {
-                "source": "https://github.com/bigcommerce/grpc-php/tree/v1.3.2-p1"
-            },
-            "time": "2017-10-19T09:52:09+00:00"
-        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
@@ -150,47 +194,6 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
-        },
-        {
-            "name": "google/protobuf",
-            "version": "v3.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/google/protobuf.git",
-                "reference": "b04e5cba356212e4e8c66c61bbe0c3a20537c5b9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/google/protobuf/zipball/b04e5cba356212e4e8c66c61bbe0c3a20537c5b9",
-                "reference": "b04e5cba356212e4e8c66c61bbe0c3a20537c5b9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": ">=4.8.0"
-            },
-            "suggest": {
-                "ext-bcmath": "Need to support JSON deserialization"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Google\\Protobuf\\": "php/src/Google/Protobuf",
-                    "GPBMetadata\\Google\\Protobuf\\": "php/src/GPBMetadata/Google/Protobuf"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "proto library for PHP",
-            "homepage": "https://developers.google.com/protocol-buffers/",
-            "keywords": [
-                "proto"
-            ],
-            "time": "2017-09-14T19:24:28+00:00"
         },
         {
             "name": "myclabs/deep-copy",


### PR DESCRIPTION
In bc-app, we use php grpc ext version 1.9.

The bug we had a patch for in bigcommerce/grpc-php https://github.com/bigcommerce/grpc-php/commit/966f7d22a52c3dfa89a5faf28644da822686c08a


was fixed:
https://github.com/grpc/grpc/pull/12706/files and released in 1.8.5

@bigcommerce/platform-engineering 