### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/tests export-ignore
+/.* export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Reasoning:
 - while [creating an archive](https://git-scm.com/docs/gitattributes#_creating_an_archive) (such as tag) files and directories with the attribute `export-ignore` won’t be added to it
 - popular libraries such as [Monolog](https://github.com/Seldaek/monolog/blob/master/.gitattributes), [PHPUnit](https://github.com/sebastianbergmann/phpunit/blob/master/.gitattributes) and [Guzzle](https://github.com/guzzle/guzzle/blob/master/.editorconfig) are doing it
