### PR TITLE
Composer normalize and coding style improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ tmp
 test.php
 coverage/
 /composer.lock
+/.php_cs
+/.php_cs.cache
+

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,4 +9,10 @@ return PhpCsFixer\Config::create()
     )
     ->setRules([
         '@PSR2' => true,
+        'header_comment' => [
+            'comment_type' => 'PHPDoc',
+            'header' => trim(file_get_contents(__DIR__ . '/LICENSE.md')),
+            'location' => 'after_open',
+            'separate' => 'none',
+        ],
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,12 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->files()
+            ->in(__DIR__ . '/src')
+            ->in(__DIR__ . '/tests')
+    )
+    ->setRules([
+        '@PSR2' => true,
+    ]);

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,5 @@ matrix:
 
 script:
   - vendor/bin/phpcs --standard=PSR2 --ignore=src/Grphp/grpc.stubs.php src
+  - vendor/bin/php-cs-fixer fix --diff --dry-run -v
   - vendor/bin/phpunit

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,8 +2,8 @@ Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
 documentation files (the "Software"), to deal in the Software without restriction, including without limitation the 
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit 
-persons to whom the Software is furnished to do so, subject to the following conditions:
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the 
 Software.

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,9 @@
     "phpunit/phpunit": "6.1.*",
     "squizlabs/php_codesniffer": "3.*"
   },
-  "config": {
-    "platform": {
-      "php": "7.0.30"
-    }
-  },
   "autoload": {
     "psr-4": {
       "Grphp\\": "src/Grphp"
     }
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "grpc/grpc": "^1.13"
   },
   "require-dev": {
+    "friendsofphp/php-cs-fixer": "^2.13",
     "phpunit/phpunit": "^6.4 || ^7.4",
     "squizlabs/php_codesniffer": "3.*"
   },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "autoload": {
     "psr-4": {
-      "": "src/"
+      "Grphp\\": "src/Grphp"
     }
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
     "grpc/grpc": "^1.13"
   },
   "require-dev": {
-    "phpunit/php-code-coverage": "^5.2@dev",
-    "phpunit/phpunit": "6.1.*",
+    "phpunit/phpunit": "^6.4 || ^7.4",
     "squizlabs/php_codesniffer": "3.*"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,27 @@
 {
   "name": "bigcommerce/grphp",
-  "description": "gRPC PHP Framework",
   "type": "library",
+  "description": "gRPC PHP Framework",
   "license": "MIT",
   "require": {
-    "grpc/grpc": "^1.13",
-    "google/protobuf": "3.5.*"
+    "google/protobuf": "3.5.*",
+    "grpc/grpc": "^1.13"
   },
   "require-dev": {
-    "phpunit/phpunit": "6.1.*",
     "phpunit/php-code-coverage": "^5.2@dev",
+    "phpunit/phpunit": "6.1.*",
     "squizlabs/php_codesniffer": "3.*"
   },
-  "autoload": {
-    "psr-4": { "": "src/"}
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true,
   "config": {
     "platform": {
       "php": "7.0.30"
     }
-  }
+  },
+  "autoload": {
+    "psr-4": {
+      "": "src/"
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/src/Grphp/Client/Channel.php
+++ b/src/Grphp/Client/Channel.php
@@ -26,5 +26,4 @@ namespace Grphp\Client;
  */
 class Channel extends \Grpc\Channel
 {
-
 }

--- a/src/Grphp/Client/FailedResponseClassLookupException.php
+++ b/src/Grphp/Client/FailedResponseClassLookupException.php
@@ -21,5 +21,4 @@ namespace Grphp\Client;
 
 class FailedResponseClassLookupException extends \Exception
 {
-
 }

--- a/src/Grphp/Client/Strategy/Grpc/Config.php
+++ b/src/Grphp/Client/Strategy/Grpc/Config.php
@@ -24,5 +24,4 @@ namespace Grphp\Client\Strategy\Grpc;
  */
 class Config
 {
-
 }

--- a/src/Grphp/Protobuf/SerializationException.php
+++ b/src/Grphp/Protobuf/SerializationException.php
@@ -21,5 +21,4 @@ namespace Grphp\Protobuf;
 
 class SerializationException extends \Exception
 {
-
 }

--- a/src/Grphp/grpc.stubs.php
+++ b/src/Grphp/grpc.stubs.php
@@ -55,7 +55,6 @@ if (!defined(\Grpc\ChannelCredentials::class)) {
 if (!defined(\Grpc\Channel::class)) {
     class Channel
     {
-
     }
 }
 
@@ -72,6 +71,5 @@ if (!defined(\Grpc\Timeval::class)) {
 if (!defined(\Grpc\Call::class)) {
     class Call
     {
-
     }
 }

--- a/tests/Support/Client.php
+++ b/tests/Support/Client.php
@@ -31,12 +31,13 @@ class StubbedCall extends AbstractCall
     private $response;
     private $options = [];
 
-    public function __construct($response,
-                                Channel $channel,
-                                $method,
-                                $deserialize,
-                                array $options = [])
-    {
+    public function __construct(
+        $response,
+        Channel $channel,
+        $method,
+        $deserialize,
+        array $options = []
+    ) {
         parent::__construct($channel, $method, $deserialize, $options);
         $this->response = $response;
         $this->options = array_merge($this->options, $options);

--- a/tests/Support/Compiled/GetThingReq.php
+++ b/tests/Support/Compiled/GetThingReq.php
@@ -34,7 +34,8 @@ class GetThingReq extends \Google\Protobuf\Internal\Message
      */
     private $id = 0;
 
-    public function __construct() {
+    public function __construct()
+    {
         \GPBMetadata\Grphp\Test\Thing::initOnce();
         parent::__construct();
     }
@@ -60,6 +61,4 @@ class GetThingReq extends \Google\Protobuf\Internal\Message
 
         return $this;
     }
-
 }
-

--- a/tests/Support/Compiled/GetThingResp.php
+++ b/tests/Support/Compiled/GetThingResp.php
@@ -34,7 +34,8 @@ class GetThingResp extends \Google\Protobuf\Internal\Message
      */
     private $thing = null;
 
-    public function __construct() {
+    public function __construct()
+    {
         \GPBMetadata\Grphp\Test\Thing::initOnce();
         parent::__construct();
     }
@@ -60,6 +61,4 @@ class GetThingResp extends \Google\Protobuf\Internal\Message
 
         return $this;
     }
-
 }
-

--- a/tests/Support/Compiled/Thing.php
+++ b/tests/Support/Compiled/Thing.php
@@ -35,7 +35,8 @@ class Thing extends \Google\Protobuf\Internal\Message
      */
     private $name = '';
 
-    public function __construct() {
+    public function __construct()
+    {
         \GPBMetadata\Grphp\Test\Thing::initOnce();
         parent::__construct();
     }
@@ -78,11 +79,9 @@ class Thing extends \Google\Protobuf\Internal\Message
      */
     public function setName($var)
     {
-        GPBUtil::checkString($var, True);
+        GPBUtil::checkString($var, true);
         $this->name = $var;
 
         return $this;
     }
-
 }
-

--- a/tests/Support/Compiled/Things.php
+++ b/tests/Support/Compiled/Things.php
@@ -24,7 +24,8 @@ class Thing
 {
     public static $is_initialized = false;
 
-    public static function initOnce() {
+    public static function initOnce()
+    {
         $pool = \Google\Protobuf\Internal\DescriptorPool::getGeneratedPool();
 
         if (static::$is_initialized == true) {
@@ -44,4 +45,3 @@ class Thing
         static::$is_initialized = true;
     }
 }
-

--- a/tests/Support/Compiled/ThingsClient.php
+++ b/tests/Support/Compiled/ThingsClient.php
@@ -19,7 +19,8 @@ namespace Grphp\Test;
 
 class ThingsClient extends \Grpc\BaseStub
 {
-    public function getExpectedResponseMessages() {
+    public function getExpectedResponseMessages()
+    {
         return [
             'getThing' => '\Grphp\Test\GetThingResp',
         ];
@@ -32,7 +33,8 @@ class ThingsClient extends \Grpc\BaseStub
      * @param array $opts channel options
      * @param \Grpc\Channel $channel (optional) re-use channel object
      */
-    public function __construct($hostname, $opts, $channel = null) {
+    public function __construct($hostname, $opts, $channel = null)
+    {
         parent::__construct($hostname, $opts, $channel);
         $this->channel = new \Grpc\Channel($hostname, $opts);
     }
@@ -43,9 +45,11 @@ class ThingsClient extends \Grpc\BaseStub
      * @param array $options call options
      * @return StubbedCall
      */
-    public function GetThing(\Grphp\Test\GetThingReq $argument,
-                             $metadata = [], $options = []) {
-
+    public function GetThing(
+        \Grphp\Test\GetThingReq $argument,
+        $metadata = [],
+        $options = []
+    ) {
         $thing = new Thing();
         $thing->setId($argument->getId());
         $thing->setName('Foo');

--- a/tests/Unit/Grphp/Authentication/BasicTest.php
+++ b/tests/Unit/Grphp/Authentication/BasicTest.php
@@ -68,5 +68,4 @@ final class BasicTest extends TestCase
         $s = base64_encode($str);
         return "Basic $s";
     }
-
 }

--- a/tests/Unit/Grphp/Authentication/BuilderTest.php
+++ b/tests/Unit/Grphp/Authentication/BuilderTest.php
@@ -1,20 +1,20 @@
 <?php
 /**
-* Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-* documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
-* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
-* permit persons to whom the Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
-* Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-* WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-* COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-* OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 namespace Grphp\Authentication;
 
 use Grphp\Client\Config;

--- a/tests/Unit/Grphp/Client/ErrorTest.php
+++ b/tests/Unit/Grphp/Client/ErrorTest.php
@@ -52,7 +52,7 @@ final class ErrorTest extends TestCase
 
         $headerRegistry = new HeaderCollection();
         $headerRegistry->add(Error::ERROR_METADATA_KEY, '{"message": "Test"}');
-        $this->status = new Error\Status(0, 'OK', $headerRegistry);;
+        $this->status = new Error\Status(0, 'OK', $headerRegistry);
     }
 
     /**

--- a/tests/Unit/Grphp/Client/HeaderTest.php
+++ b/tests/Unit/Grphp/Client/HeaderTest.php
@@ -21,7 +21,6 @@ use PHPUnit\Framework\TestCase;
 
 final class HeaderTest extends TestCase
 {
-
     public function testGetName()
     {
         $header = new Header('Foo');


### PR DESCRIPTION
This PR:
- [normalizes](https://github.com/localheinz/composer-normalize) `composer.json`
- fixes autoload configuration
- removes unnecessary options from `composer.json`
- upgrades PHPUnit to use v7 in PHP 7.1+
- adds [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) and fixes code with it to follow PSR2
- unifies header comments