### PR TITLE
Replaces http1 encoding header with `identity` rather than content type

### DIFF
--- a/src/Grphp/Client/Strategy/H2Proxy/RequestExecutor.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestExecutor.php
@@ -28,6 +28,7 @@ class RequestExecutor
 {
     const GRPC_BINARY_ENCODED_METADATA_POSTFIX = '-bin';
     const GRPC_CONTENT_TYPE = 'application/grpc+proto';
+    const GRPC_ENCODING = 'identity';
     const GRPC_STATUS_HEADER = 'grpc-status';
     const GRPC_STATUS_OK = '0';
     const GRPHP_USER_AGENT = 'grphp/1.0.0';
@@ -133,7 +134,7 @@ class RequestExecutor
             CURLOPT_POSTFIELDS => $payload,
             CURLOPT_HEADER => true,
             CURLOPT_USERAGENT => static::GRPHP_USER_AGENT,
-            CURLOPT_ENCODING => static::GRPC_CONTENT_TYPE
+            CURLOPT_ENCODING => static::GRPC_ENCODING
         ];
     }
 }


### PR DESCRIPTION
The RequestExecutor in H2 strategy is currently sending the content-type as the accept-encoding header:
`Accept-Encoding: application/grpc+proto`
This PR updates it to `identity`. The `content-type` header is already provided - see sample request below:
````
POST / HTTP/1.1
Host: http://host:port/rpc.service.path/RPCAction
Accept: */*
Accept-Encoding: application/grpc+proto
authorization: Basic 12345678
deadline: 1548000000.1378
upgrade: h2c
connection: Upgrade
content-type: application/grpc+proto
te: trailers
user-agent: grphp/1.0.0
grpc-encoding: identity
Content-Length: 7

\x00\x00\x00\x00\x02\x10\x0e
````

@splittingred @bigcommerce/platform-engineering 