### PR TITLE
Add support for proxy configuration with H2Proxy Strategy

### DIFF
--- a/src/Grphp/Client/Strategy/H2Proxy/Config.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/Config.php
@@ -15,7 +15,7 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Grphp\Client\Strategy\H2Proxy;
 
@@ -24,23 +24,33 @@ namespace Grphp\Client\Strategy\H2Proxy;
  */
 class Config
 {
+    const DEFAULT_PROXY_ADDRESS = '127.0.0.1:3000';
     const DEFAULT_ADDRESS = '0.0.0.0:3000';
     /** @var int The default timeout for connecting to the nghttpx proxy and resolving its result */
     const DEFAULT_TIMEOUT = 15;
 
     /** @var string */
     private $baseUri;
+
+    /** @var string */
+    private $proxyUri;
+
     /** @var int */
     private $timeout;
 
     /**
      * @param string $baseUri The address and port of the nghttpx proxy
      * @param int $timeout The timeout to connect to the proxy, in seconds
+     * @param string $proxyUri
      */
-    public function __construct(string $baseUri = Config::DEFAULT_ADDRESS, int $timeout = Config::DEFAULT_TIMEOUT)
-    {
+    public function __construct(
+        string $baseUri = Config::DEFAULT_ADDRESS,
+        int $timeout = Config::DEFAULT_TIMEOUT,
+        string $proxyUri = Config::DEFAULT_PROXY_ADDRESS
+    ) {
         $this->baseUri = $baseUri;
         $this->timeout = $timeout;
+        $this->proxyUri = $proxyUri;
     }
 
     /**
@@ -57,5 +67,13 @@ class Config
     public function getTimeout(): int
     {
         return $this->timeout;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProxyUri(): string
+    {
+        return $this->proxyUri;
     }
 }

--- a/src/Grphp/Client/Strategy/H2Proxy/Request.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/Request.php
@@ -24,6 +24,8 @@ use Grphp\Client\HeaderCollection;
 class Request
 {
     /** @var string */
+    private $proxyUri;
+    /** @var string */
     private $url;
     /** @var string */
     private $message;
@@ -34,12 +36,14 @@ class Request
      * @param string $url The URL of the nghttpx proxy
      * @param string $message The binary serialized protobuf message
      * @param HeaderCollection $headers Headers to send
+     * @param string $proxyUri
      */
-    public function __construct(string $url, string $message, HeaderCollection $headers)
+    public function __construct(string $url, string $message, HeaderCollection $headers, string $proxyUri = '')
     {
         $this->url = $url;
         $this->message = $message;
         $this->headers = $headers;
+        $this->proxyUri = $proxyUri;
     }
 
     /**
@@ -64,5 +68,13 @@ class Request
     public function getHeaders(): HeaderCollection
     {
         return $this->headers;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProxyUri(): string
+    {
+        return $this->proxyUri;
     }
 }

--- a/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
@@ -54,7 +54,7 @@ class RequestFactory
         $url = trim($this->config->getBaseUri(), '/') . '/' . $requestContext->getPath();
         $message = $this->serializer->serializeRequest($requestContext);
         $headers = $this->buildHeaders($requestContext);
-        return new Request($url, $message, $headers);
+        return new Request($url, $message, $headers, $this->config->getProxyUri());
     }
 
     /**

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/ConfigTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/ConfigTest.php
@@ -45,5 +45,6 @@ final class ConfigTest extends TestCase
         $config = new Config();
         static::assertEquals(Config::DEFAULT_ADDRESS, $config->getBaseUri());
         static::assertEquals(Config::DEFAULT_TIMEOUT, $config->getTimeout());
+        static::assertEquals(Config::DEFAULT_PROXY_ADDRESS, $config->getProxyUri());
     }
 }


### PR DESCRIPTION
## What?
Adds support for proxy configuration when using the H2 strategy separate from the service URI.

## Why?
nghttpx fails to include the `:authority` pseudo header for upgraded requests to http2 without being configured as a proxy (`http2-proxy=yes` config option), and some grpc services treat this pseudo header as mandatory (i.e Tower/H2 in rust). This was causing PROTOCOL errors when grphp made requests to prophet via nghttpx. 

Rather than changing the configuration of nghttpx (which is working fine for other service <=> service comms) we can configure grphp to connect to nghttpx as a proxy, which forces nghttpx to append the pseudo header correctly.

This also likely makes sense outside our own environments as others may use grphp without a service mesh so allowing clients to configure upgrade proxy + service address separately is likely preferable.

## How was this tested?
New unit tests, confirmed https://bigcommerce.slack.com/archives/CDL5WDANB/p1549933768009900 original issue addressed with the fix.

@splittingred @zackangelo @bigcommerce/platform-engineering @bigcommerce/checkout 