### PR TITLE
Remove default from proxy option (should default to disabled)

### DIFF
--- a/src/Grphp/Client/Strategy/H2Proxy/Config.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/Config.php
@@ -24,7 +24,6 @@ namespace Grphp\Client\Strategy\H2Proxy;
  */
 class Config
 {
-    const DEFAULT_PROXY_ADDRESS = '127.0.0.1:3000';
     const DEFAULT_ADDRESS = '0.0.0.0:3000';
     /** @var int The default timeout for connecting to the nghttpx proxy and resolving its result */
     const DEFAULT_TIMEOUT = 15;
@@ -46,7 +45,7 @@ class Config
     public function __construct(
         string $baseUri = Config::DEFAULT_ADDRESS,
         int $timeout = Config::DEFAULT_TIMEOUT,
-        string $proxyUri = Config::DEFAULT_PROXY_ADDRESS
+        string $proxyUri = ''
     ) {
         $this->baseUri = $baseUri;
         $this->timeout = $timeout;

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/ConfigTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/ConfigTest.php
@@ -45,6 +45,6 @@ final class ConfigTest extends TestCase
         $config = new Config();
         static::assertEquals(Config::DEFAULT_ADDRESS, $config->getBaseUri());
         static::assertEquals(Config::DEFAULT_TIMEOUT, $config->getTimeout());
-        static::assertEquals(Config::DEFAULT_PROXY_ADDRESS, $config->getProxyUri());
+        static::assertEquals('', $config->getProxyUri());
     }
 }


### PR DESCRIPTION
In https://github.com/bigcommerce/grphp/pull/24/files#diff-5e980d9fdbbe12c88c536a62f98cb97bR27 the proxy address was set to a default, however the intention is for proxying to remain disabled by default and only be enabled explicitly.

This change removes the default value.