### PR TITLE
Include connection error messages in exceptions

### DIFF
--- a/src/Grphp/Client/Strategy/H2Proxy/RequestException.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestException.php
@@ -50,7 +50,7 @@ class RequestException extends \Exception
     public function getErrorMessage(): string
     {
         $header = $this->headers->get('grpc-message');
-        return $header ? $header->getFirstValue() : '';
+        return $header ? $header->getFirstValue() : substr($this->body, 0, 255);
     }
 
     /**

--- a/src/Grphp/Client/Strategy/H2Proxy/RequestExecutor.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestExecutor.php
@@ -79,7 +79,7 @@ class RequestExecutor
 
         $response = curl_exec($ch);
         if (empty($response)) {
-            throw new RequestException('Empty body from nghttpx proxy', $responseHeaders);
+            throw new RequestException('Empty body from nghttpx proxy: ' . curl_error($ch), $responseHeaders);
         }
 
         $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);


### PR DESCRIPTION
## What & why

Updates grphp error messaging to:
- Read error message from curl (if we fail to get any error messaging back - usually because of things like failing to resolve host, network issues, etc)
- If we receive a body but it doesn't include an "OK" grpc status but also doesn't include a grpc message, to dump the first 255 characters of the body as the message (which will be the service mesh resolution failure message if we successfully connect to linkerd but fail to resolve the service).

This cause a lot of frustration when engineers were trying to to work out why there services weren't working, usually due to easily resolved issues such as misconfigurations, missing VPN connections, etc, so should make it easier to identify the cause of failure.

## Proof

>broken address
![image](https://user-images.githubusercontent.com/1628237/55724315-83ff3400-5a4e-11e9-88b8-90f6e2340be3.png)


@bigcommerce/platform-engineering @bigcommerce/checkout @aleachjr 