### PR TITLE
Update google/protobuf dependency to 3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "gRPC PHP Framework",
   "license": "MIT",
   "require": {
-    "google/protobuf": "3.5.*",
+    "google/protobuf": "^3.7",
     "grpc/grpc": "^1.13"
   },
   "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          processIsolation="false"
          backupGlobals="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          colors="true">
 
     <testsuites>
@@ -16,16 +15,7 @@
         </testsuite>
     </testsuites>
 
-    <groups>
-        <exclude>
-            <group>deprecated</group>
-        </exclude>
-    </groups>
-
     <filter>
-        <blacklist>
-            <directory>./vendor/*</directory>
-        </blacklist>
         <whitelist>
             <directory>./src</directory>
         </whitelist>
@@ -34,6 +24,6 @@
     <logging>
         <log type="coverage-html" target="coverage" lowUpperBound="35" highLowerBound="70"/>
         <log type="coverage-clover" target="coverage/coverage.xml"/>
-        <log type="junit" target="coverage/junit.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="coverage/junit.xml"/>
     </logging>
 </phpunit>

--- a/src/Grphp/grpc.stubs.php
+++ b/src/Grphp/grpc.stubs.php
@@ -23,8 +23,7 @@ const STATUS_INTERNAL = 13;
 const STATUS_UNKNOWN = 2;
 const STATUS_OK = 0;
 
-
-if (!defined(\Grpc\ChannelCredentials::class)) {
+if (!class_exists(\Grpc\ChannelCredentials::class, false)) {
     class ChannelCredentials
     {
         /**
@@ -52,13 +51,13 @@ if (!defined(\Grpc\ChannelCredentials::class)) {
     }
 }
 
-if (!defined(\Grpc\Channel::class)) {
+if (!class_exists(\Grpc\Channel::class, false)) {
     class Channel
     {
     }
 }
 
-if (!defined(\Grpc\Timeval::class)) {
+if (!class_exists(\Grpc\Timeval::class, false)) {
     class Timeval
     {
         public static function infFuture()
@@ -68,7 +67,7 @@ if (!defined(\Grpc\Timeval::class)) {
     }
 }
 
-if (!defined(\Grpc\Call::class)) {
+if (!class_exists(\Grpc\Call::class, false)) {
     class Call
     {
     }


### PR DESCRIPTION
Main change:
- Update `google/protobuf` library to `^3.7`;

Bonus:
- Remove obsolete PHPUnit options from the XML configuration file;
- Replace `defined()` with `class_exists()` when checking for availability of the classes before providing stubs;

ping @bigcommerce/platform-engineering @bigcommerce/platform-australia 