### PR TITLE
Ensure that the H2Proxy request has schema in the URI

### DIFF
--- a/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
@@ -51,7 +51,7 @@ class RequestFactory
      */
     public function build(RequestContext $requestContext): Request
     {
-        $url = trim($this->config->getBaseUri(), '/') . '/' . $requestContext->getPath();
+        $url = $this->getBaseUri() . '/' . ltrim($requestContext->getPath(), '/');
         $message = $this->serializer->serializeRequest($requestContext);
         $headers = $this->buildHeaders($requestContext);
         return new Request($url, $message, $headers, $this->config->getProxyUri());
@@ -86,5 +86,21 @@ class RequestFactory
         $headers->add('User-Agent', 'grphp/1.0.0');
         $headers->add('Grpc-Encoding', 'identity');
         return $headers;
+    }
+
+    /**
+     * Prepend schema to a given base URI if necessary
+     *
+     * @return string
+     */
+    private function getBaseUri(): string
+    {
+        $baseUri = trim($this->config->getBaseUri(), '/');
+
+        if (parse_url($baseUri, PHP_URL_SCHEME)) {
+            return $baseUri;
+        }
+
+        return 'http://' . $baseUri;
     }
 }


### PR DESCRIPTION
Currently, H2Proxy request builder is creating a full request URI by combining base URI and a request path. A base URI, however might not have scheme provided and when such a request is sent to certain HTTP servers they will treat this URL as path and mishandle the request. This PR introduces a check to verify that base URI has a scheme and prepends `http://` if it does not.

ping @bigcommerce/platform-australia @bigcommerce/platform-engineering 