### PR TITLE
Ensure that grpc-status code is properly propagated in the thrown exception

### DIFF
--- a/src/Grphp/Client/Error.php
+++ b/src/Grphp/Client/Error.php
@@ -19,6 +19,7 @@ declare(strict_types = 1);
 
 namespace Grphp\Client;
 
+use Exception;
 use Grphp\Client\Error\Status;
 use Grphp\Serializers\Errors\Base as BaseSerializer;
 
@@ -28,18 +29,18 @@ use Grphp\Serializers\Errors\Base as BaseSerializer;
  *
  * @package Grphp\Client
  */
-class Error extends \Exception
+class Error extends Exception
 {
     /** @const string */
     const ERROR_METADATA_KEY = 'error-internal-bin';
 
-    /** @var \stdClass $status */
+    /** @var Status $status */
     protected $status;
     /** @var Config $config */
     private $config;
 
     /**
-     * @param \Grphp\Client\Config $config
+     * @param Config $config
      * @param Status $status
      */
     public function __construct(Config $config, Status $status)

--- a/src/Grphp/Client/Strategy/H2Proxy/Strategy.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/Strategy.php
@@ -71,7 +71,7 @@ class Strategy implements StrategyInterface
         try {
             $response = $this->requestExecutor->send($request);
         } catch (RequestException $e) {
-            $status = new Error\Status(Error\Status::CODE_INTERNAL, $e->getErrorMessage(), $e->getHeaders());
+            $status = new Error\Status($e->getCode(), $e->getMessage(), $e->getHeaders());
             $clientRequest->fail($status);
         }
 


### PR DESCRIPTION
Originally, the `Status` instance that is created in response of the request exception always had its code set to `INTERNAL` (13). As a result, an exception that is thrown prevents clients from properly understanding what the server is trying to tell them, without inspecting the header field themselves.

This PR reads the code from the `grpc-status` header (or rather trailer) field and uses it as a code for an exception that is thrown, and only falls back onto `UNKNOWN` (2), instead of `INTERNAL`, if the `grpc-status` trailer is missing.

@bigcommerce/platform-australia @bigcommerce/platform-engineering 