### PR TITLE
Ensure that base URI contains scheme

### DIFF
--- a/src/Grphp/Client/Strategy/H2Proxy/Config.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/Config.php
@@ -19,12 +19,14 @@ declare(strict_types=1);
 
 namespace Grphp\Client\Strategy\H2Proxy;
 
+use InvalidArgumentException;
+
 /**
  * Configuration for the h2proxy strategy
  */
 class Config
 {
-    const DEFAULT_ADDRESS = '0.0.0.0:3000';
+    const DEFAULT_ADDRESS = 'http://0.0.0.0:3000';
     /** @var int The default timeout for connecting to the nghttpx proxy and resolving its result */
     const DEFAULT_TIMEOUT = 15;
 
@@ -43,13 +45,26 @@ class Config
      * @param string $proxyUri
      */
     public function __construct(
-        string $baseUri = Config::DEFAULT_ADDRESS,
-        int $timeout = Config::DEFAULT_TIMEOUT,
+        string $baseUri = self::DEFAULT_ADDRESS,
+        int $timeout = self::DEFAULT_TIMEOUT,
         string $proxyUri = ''
     ) {
-        $this->baseUri = $baseUri;
+        $this->baseUri = $this->validateBaseUri($baseUri);
         $this->timeout = $timeout;
         $this->proxyUri = $proxyUri;
+    }
+
+    /**
+     * @param string $baseUri
+     * @return string
+     */
+    private function validateBaseUri(string $baseUri): string
+    {
+        if (!parse_url($baseUri, PHP_URL_SCHEME)) {
+            throw new InvalidArgumentException("Wrong base URI provided, scheme is missing: {$baseUri}");
+        }
+
+        return $baseUri;
     }
 
     /**

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/ConfigTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/ConfigTest.php
@@ -17,34 +17,45 @@
  */
 namespace Grphp\Client\Strategy\H2Proxy;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
 {
-    /**
-     * @param string $baseUri
-     * @param int $timeout
-     * @dataProvider providerCustom
-     */
-    public function testCustom(string $baseUri, int $timeout)
+    public function testConfigWithTimeout()
     {
+        $baseUri = 'http://localhost:1234';
+        $timeout = 5;
+
         $config = new Config($baseUri, $timeout);
-        static::assertEquals($baseUri, $config->getBaseUri());
-        static::assertEquals($timeout, $config->getTimeout());
-    }
-    public function providerCustom()
-    {
-        return [
-            ['localhost:1234', 5],
-            ['my.service:5000', 0]
-        ];
+
+        $this->assertSame($baseUri, $config->getBaseUri());
+        $this->assertSame($timeout, $config->getTimeout());
     }
 
-    public function testDefaults()
+    public function testConfigWithoutTimeout()
+    {
+        $baseUri = 'https://my.service:5000';
+        $timeout = 0;
+
+        $config = new Config($baseUri, $timeout);
+
+        $this->assertSame($baseUri, $config->getBaseUri());
+        $this->assertSame($timeout, $config->getTimeout());
+    }
+
+    public function testConfigWithDefaults()
     {
         $config = new Config();
-        static::assertEquals(Config::DEFAULT_ADDRESS, $config->getBaseUri());
-        static::assertEquals(Config::DEFAULT_TIMEOUT, $config->getTimeout());
-        static::assertEquals('', $config->getProxyUri());
+        $this->assertSame(Config::DEFAULT_ADDRESS, $config->getBaseUri());
+        $this->assertSame(Config::DEFAULT_TIMEOUT, $config->getTimeout());
+        $this->assertSame('', $config->getProxyUri());
+    }
+
+    public function testConfigRejectsBaseUriWithoutAScheme()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Config('service.internal:8080');
     }
 }


### PR DESCRIPTION
Currently the H2 config class accepts base URIs that contain no schema. When a request is sent through proxy, certain services that expecting fully qualified request URIs that must include a scheme and will fail if a scheme isn't present. This PR introduces validation of a base URI at the time of config instantiation and throws an exception if scheme is not provided.