### PR TITLE
Run Travis against supported and stable PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,17 @@ before_install:
 
 matrix:
     include:
-        - name: PHP 7.0 with lowest versions of dependencies
-          php: '7.0'
+        - name: PHP 7.2 with lowest versions of dependencies
+          php: '7.2'
           install: composer update --prefer-lowest
-        - name: PHP 7.0
-          php: '7.0'
-          install: composer update
-        - name: PHP 7.1
-          php: '7.1'
-          install: composer update
         - name: PHP 7.2
           php: '7.2'
+          install: composer update
+        - name: PHP 7.3
+          php: '7.3'
+          install: composer update
+        - name: PHP 7.4
+          php: '7.4'
           install: composer update
 
 script:


### PR DESCRIPTION
PHP 7.0 and 7.1 are no longer supported according to [php.net](https://www.php.net/supported-versions.php). PHP 7.3 and 7.4 in contrast are now. Test everything against 7.2 to 7.4 versions.