### PR TITLE
Refactor error metadata key handling

### DIFF
--- a/src/Grphp/Client/Config.php
+++ b/src/Grphp/Client/Config.php
@@ -31,56 +31,40 @@ use Grphp\Serializers\Errors\Json as JsonSerializer;
 class Config
 {
     /** @var string $hostname */
-    public $hostname = '';
+    public $hostname;
     /** @var string $authentication */
     public $authentication;
     /** @var array $authenticationOptions */
-    public $authenticationOptions = [];
+    public $authenticationOptions;
     /** @var string $errorSerializer */
     public $errorSerializer;
     /** @var array $errorSerializerOptions */
-    public $errorSerializerOptions = [];
+    public $errorSerializerOptions;
     /** @var string $errorMetadataKey */
-    public $errorMetadataKey = 'error-internal-bin';
+    public $errorMetadataKey;
     /** @var array $interceptorOptions */
-    public $interceptorOptions = [];
+    public $interceptorOptions;
     /** @var bool $useDefaultInterceptors */
-    public $useDefaultInterceptors = true;
+    public $useDefaultInterceptors;
     /** @var \stdClass */
     private $strategy;
+
+    private const ERROR_METADATA_KEY = 'error-internal-bin';
 
     /**
      * @param array $options
      */
     public function __construct($options = [])
     {
-        $this->hostname = array_key_exists('hostname', $options)
-            ? $options['hostname']
-            : '';
-        $this->authentication = array_key_exists('authentication', $options)
-            ? $options['authentication']
-            : null;
-        $this->authenticationOptions = array_key_exists('authentication_options', $options)
-            ? $options['authentication_options']
-            : [];
-        $this->errorSerializer = array_key_exists('error_serializer', $options)
-            ? $options['error_serializer']
-            : JsonSerializer::class;
-        $this->errorSerializerOptions = array_key_exists('error_serializer_options', $options)
-            ? $options['error_serializer_options']
-            : [];
-        $this->errorMetadataKey = array_key_exists('error_metadata_key', $options)
-            ? $options['error_metadata_key']
-            : 'error-internal-bin';
-        $this->interceptorOptions = array_key_exists('interceptor_options', $options)
-            ? $options['interceptor_options']
-            : [];
-        $this->useDefaultInterceptors = array_key_exists('use_default_interceptors', $options)
-            ? $options['use_default_interceptors']
-            : true;
-        $this->strategy = array_key_exists('strategy', $options)
-            ? $options['strategy']
-            : new GrpcStrategy(new GrpcConfig());
+        $this->hostname = $options['hostname'] ?? '';
+        $this->authentication = $options['authentication'] ?? null;
+        $this->authenticationOptions = $options['authentication_options'] ?? [];
+        $this->errorSerializer = $options['error_serializer'] ?? JsonSerializer::class;
+        $this->errorSerializerOptions = $options['error_serializer_options'] ?? [];
+        $this->errorMetadataKey = $options['error_metadata_key'] ?? self::ERROR_METADATA_KEY;
+        $this->interceptorOptions = $options['interceptor_options'] ?? [];
+        $this->useDefaultInterceptors = $options['use_default_interceptors'] ?? true;
+        $this->strategy = $options['strategy'] ?? new GrpcStrategy(new GrpcConfig());
     }
 
     /**

--- a/src/Grphp/Client/Config.php
+++ b/src/Grphp/Client/Config.php
@@ -84,4 +84,12 @@ class Config
         $this->strategy = $strategy;
         return $this;
     }
+
+    /**
+     * @return string
+     */
+    public function getErrorMetadataKey(): string
+    {
+        return $this->errorMetadataKey;
+    }
 }

--- a/tests/Unit/Grphp/Client/ErrorTest.php
+++ b/tests/Unit/Grphp/Client/ErrorTest.php
@@ -33,6 +33,8 @@ final class ErrorTest extends TestCase
     /** @var \Grphp\Client\Config */
     private $clientConfig;
 
+    private const ERROR_METADATA_KEY = 'error-internal-bin';
+
     private function buildClient(array $options = [])
     {
         $options = array_merge([
@@ -51,7 +53,7 @@ final class ErrorTest extends TestCase
         $this->elapsed = rand(0.0, 20.0);
 
         $headerRegistry = new HeaderCollection();
-        $headerRegistry->add(Error::ERROR_METADATA_KEY, '{"message": "Test"}');
+        $headerRegistry->add('error-internal-bin', '{"message": "Test"}');
         $this->status = new Error\Status(0, 'OK', $headerRegistry);
     }
 


### PR DESCRIPTION
## What & why?
1. Move `ERROR_METADATA_KEY` constant to `Config` class and use it as a default value, making it private to the class.
2. Introduce a getter to fetch error metadata key name, instead of relying on public properties.
3. Refactor client classes to use new metadata key getter.