### PR TITLE
Improve exception messages

### DIFF
--- a/src/Grphp/Client/Strategy/H2Proxy/Strategy.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/Strategy.php
@@ -19,8 +19,8 @@ declare(strict_types = 1);
 
 namespace Grphp\Client\Strategy\H2Proxy;
 
-use Grphp\Client\Error;
 use Grphp\Client\ErrorStatus;
+use Grphp\Client\Error\Status;
 use Grphp\Client\Request as ClientRequest;
 use Grphp\Client\Response as ClientResponse;
 use Grphp\Client\Strategy\StrategyInterface;
@@ -60,7 +60,7 @@ class Strategy implements StrategyInterface
      *
      * @param ClientRequest $clientRequest
      * @return ClientResponse
-     * @throws Error
+     * @throws \Grphp\Client\Error
      * @throws \Google\Protobuf\Internal\Exception
      * @throws \Grphp\Protobuf\SerializationException
      */
@@ -71,8 +71,8 @@ class Strategy implements StrategyInterface
         try {
             $response = $this->requestExecutor->send($request);
         } catch (RequestException $e) {
-            $status = new Error\Status($e->getCode(), $e->getMessage(), $e->getHeaders());
-            $clientRequest->fail($status);
+            $message = "gRPC call `{$clientRequest->getPath()}` failed with `{$e->getMessage()}`";
+            $clientRequest->fail(new Status($e->getCode(), $message, $e->getHeaders()));
         }
 
         return $this->handleSuccess($clientRequest, $response);
@@ -92,7 +92,7 @@ class Strategy implements StrategyInterface
             $clientRequest->getExpectedResponseMessageClass()
         );
 
-        $status = new Error\Status(Error\Status::CODE_OK, '', $response->getHeaders());
+        $status = new Status(Status::CODE_OK, '', $response->getHeaders());
         return $clientRequest->succeed($responseMessage, $status);
     }
 }

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/StrategyTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/StrategyTest.php
@@ -115,14 +115,14 @@ final class StrategyTest extends TestCase
         $headers->add('grpc-message', 'Unathorized');
         $body = 'Unauthorized, sorry!';
 
-        $expectedStatus = new Status(16, 'Unathorized', $headers);
-
         $request = $this->prophesize(Request::class);
+        $request->getPath()->willReturn("foo.barService/BazCall");
 
         $config = $this->config;
-        $request->fail($expectedStatus)->will(function (array $args) use ($config) {
-            throw new Error($config, $args[0]);
-        });
+        $request->fail(Argument::allOf(Argument::Type(Status::class), Argument::which('getCode', 16)))
+            ->will(function (array $args) use ($config) {
+                throw new Error($config, $args[0]);
+            });
 
         $h2Request = $this->prophesize(H2ProxyRequest::class);
 
@@ -152,14 +152,14 @@ final class StrategyTest extends TestCase
         $headers = new HeaderCollection();
         $body = 'Everything is on fire!';
 
-        $expectedStatus = new Status(2, 'Everything is on fire!', $headers);
-
         $request = $this->prophesize(Request::class);
+        $request->getPath()->willReturn("foo.bar.bazService/GetThing");
 
         $config = $this->config;
-        $request->fail($expectedStatus)->will(function (array $args) use ($config) {
-            throw new Error($config, $args[0]);
-        });
+        $request->fail(Argument::allOf(Argument::Type(Status::class), Argument::which('getCode', 2)))
+            ->will(function (array $args) use ($config) {
+                throw new Error($config, $args[0]);
+            });
 
         $h2Request = $this->prophesize(H2ProxyRequest::class);
 


### PR DESCRIPTION
~Based on #34 and will be merged after the parent, so only last commit is really relevant here.~ merged

## What and why?
Extend exception messages to include an endpoint that we have failed to talk to to aid in debugging.

Exception message looks the following way now:
```
gRPC call `foo.bar.BazService/GetThing` failed with `Some interesting reason`
```