### PR TITLE
Fix service name deriving from a client class name in Request

### DIFF
--- a/src/Grphp/Client/Request.php
+++ b/src/Grphp/Client/Request.php
@@ -173,7 +173,7 @@ class Request
     {
         $service = explode('\\', get_class($this->client));
         $clientName = array_pop($service);
-        $clientName = str_replace('Client', '', $clientName);
+        $clientName = preg_replace('/Client\z/', '', $clientName);
         return strtolower(implode('.', $service)) . '.' . $clientName;
     }
 }

--- a/tests/Support/Client.php
+++ b/tests/Support/Client.php
@@ -19,6 +19,8 @@ namespace Grphp\Test;
 
 require_once __DIR__ . '/Compiled/Things.php';
 require_once __DIR__ . '/Compiled/ThingsClient.php';
+require_once __DIR__ . '/Compiled/DummyClient.php';
+require_once __DIR__ . '/Compiled/DummyClientAgainClient.php';
 require_once __DIR__ . '/Compiled/Thing.php';
 require_once __DIR__ . '/Compiled/GetThingReq.php';
 require_once __DIR__ . '/Compiled/GetThingResp.php';

--- a/tests/Support/Compiled/DummyClient.php
+++ b/tests/Support/Compiled/DummyClient.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Grphp\Test;
+
+class DummyClient extends \Grpc\BaseStub
+{
+    public function __construct()
+    {
+    }
+}

--- a/tests/Support/Compiled/DummyClientAgainClient.php
+++ b/tests/Support/Compiled/DummyClientAgainClient.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Grphp\Test;
+
+class DummyClientAgainClient extends \Grpc\BaseStub
+{
+    public function __construct()
+    {
+    }
+}

--- a/tests/Unit/Grphp/Client/RequestTest.php
+++ b/tests/Unit/Grphp/Client/RequestTest.php
@@ -22,6 +22,8 @@ use Grphp\Client\Error\Status;
 use Grphp\Test\GetThingReq;
 use Grphp\Test\GetThingResp;
 use Grphp\Test\ThingsClient;
+use Grphp\Test\DummyClient;
+use Grphp\Test\DummyClientAgainClient;
 use PHPUnit\Framework\TestCase;
 
 final class RequestTest extends TestCase
@@ -76,10 +78,10 @@ final class RequestTest extends TestCase
 
     public function testGetPath()
     {
-        $request = $this->buildRequest();
+        $request = new Request($this->config, 'GetThings', null, new DummyClient());
         $path = $request->getPath();
-        static::assertStringStartsWith('double.grphp.test.thingsclient', $path);
-        static::assertStringEndsWith('/GetThing', $path);
+
+        static::assertEquals('grphp.test.Dummy/GetThings', $path);
     }
 
     public function testBuildDefaultDeadline()
@@ -101,8 +103,11 @@ final class RequestTest extends TestCase
 
     public function testGetServiceName()
     {
-        $request = $this->buildRequest();
-        static::assertStringStartsWith('double.grphp.test.thingsclient', $request->getServiceName());
+        $request = new Request($this->config, 'GetThings', null, new DummyClient());
+        static::assertEquals('grphp.test.Dummy', $request->getServiceName());
+
+        $request = new Request($this->config, 'GetThings', null, new DummyClientAgainClient());
+        static::assertEquals('grphp.test.DummyClientAgain', $request->getServiceName());
     }
 
     public function testFail()


### PR DESCRIPTION
Fix generating a service name when it contains `Client` word.

Service name is derived from a client class name by removing `Client` suffix, e.g for `ThingsClient` the service name would be `Things`. But when service name already has `Client` word it's removed too.

For instance when service is`PublicClientTokens` and client class is `PublicClientTokensClient` the incorrect derived service name will be `PublicTokens`.

Changes:
- fixed service name deriving and remove only trailing `Client` word in a client class name
- refactored several unit tests to use actual client classes instead of mock objects