### PR TITLE
Enable support for client timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ coverage/
 /composer.lock
 /.php_cs
 /.php_cs.cache
-
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.13",
-    "phpunit/phpunit": "^6.4 || ^7.4",
+    "phpunit/phpunit": "^6.4 || ^7.4 || ^8.0",
     "squizlabs/php_codesniffer": "3.*"
   },
   "autoload": {

--- a/src/Grphp/Client/Config.php
+++ b/src/Grphp/Client/Config.php
@@ -46,7 +46,7 @@ class Config
     public $interceptorOptions;
     /** @var bool $useDefaultInterceptors */
     public $useDefaultInterceptors;
-    /** @var \stdClass */
+    /** @var StrategyInterface */
     private $strategy;
 
     private const ERROR_METADATA_KEY = 'error-internal-bin';

--- a/src/Grphp/Client/Request.php
+++ b/src/Grphp/Client/Request.php
@@ -176,4 +176,12 @@ class Request
         $clientName = preg_replace('/Client\z/', '', $clientName);
         return strtolower(implode('.', $service)) . '.' . $clientName;
     }
+
+    /**
+     * @return float|null
+     */
+    public function getTimeout(): ?float
+    {
+        return $this->options['timeout'] ?? null;
+    }
 }

--- a/src/Grphp/Client/Request.php
+++ b/src/Grphp/Client/Request.php
@@ -130,19 +130,19 @@ class Request
      * @return string
      * @throws FailedResponseClassLookupException
      */
-    public function getExpectedResponseMessageClass()
+    public function getExpectedResponseMessageClass(): string
     {
         $method = lcfirst($this->method);
         $clientClass = get_class($this->client);
         if (!method_exists($this->client, 'getExpectedResponseMessages')) {
             throw new FailedResponseClassLookupException(
-                "No getExpectedResponseMessages method found on {$clientClass}, is bc-interfaces up to date?"
+                "No getExpectedResponseMessages method found on the {$clientClass} client class"
             );
         }
         $clientResponses = $this->client->getExpectedResponseMessages();
         if (!array_key_exists($method, $clientResponses)) {
             throw new FailedResponseClassLookupException(
-                "No response class mapping found for $method on client {$clientClass}"
+                "No response class mapping found for {$method} on the {$clientClass} client class"
             );
         }
         return $clientResponses[$method];
@@ -159,7 +159,7 @@ class Request
     /**
      * @return float
      */
-    public function buildDeadline() : float
+    public function buildDeadline(): float
     {
         $options = $this->getOptions();
         $timeout = floatval($options['timeout'] ?? static::DEFAULT_TIMEOUT);

--- a/src/Grphp/Client/Strategy/H2Proxy/Request.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/Request.php
@@ -31,19 +31,28 @@ class Request
     private $message;
     /** @var HeaderCollection */
     private $headers;
+    /** @var float|null */
+    private $timeout;
 
     /**
      * @param string $url The URL of the nghttpx proxy
      * @param string $message The binary serialized protobuf message
      * @param HeaderCollection $headers Headers to send
      * @param string $proxyUri
+     * @param float|null $timeout
      */
-    public function __construct(string $url, string $message, HeaderCollection $headers, string $proxyUri = '')
-    {
+    public function __construct(
+        string $url,
+        string $message,
+        HeaderCollection $headers,
+        string $proxyUri = '',
+        ?float $timeout = null
+    ) {
         $this->url = $url;
         $this->message = $message;
         $this->headers = $headers;
         $this->proxyUri = $proxyUri;
+        $this->timeout = $timeout;
     }
 
     /**
@@ -76,5 +85,13 @@ class Request
     public function getProxyUri(): string
     {
         return $this->proxyUri;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getTimeout(): ?float
+    {
+        return $this->timeout;
     }
 }

--- a/src/Grphp/Client/Strategy/H2Proxy/RequestExecutor.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestExecutor.php
@@ -148,7 +148,6 @@ class RequestExecutor
         $headers[] = self::EXPECT_CONTINUE_DISABLING_HEADER;
         $curlOptions = [
             CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_BINARYTRANSFER => true,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_CUSTOMREQUEST => 'POST',
             CURLOPT_HTTPHEADER => $headers,

--- a/src/Grphp/Client/Strategy/H2Proxy/RequestExecutor.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestExecutor.php
@@ -37,6 +37,7 @@ class RequestExecutor
     const PACK_START = 5;
     private const UNCOMPRESSED_EMPTY_GRPC_MESSAGE = "\x00\x00\x00\x00\x00";
     private const COMPRESSED_EMPTY_GRPC_MESSAGE = "\x01\x00\x00\x00\x00";
+    private const MILLISECONDS_IN_SECOND = 1000;
     /**
      * curl automatically sets "expect: 100-continue" header, if either
      * - the request is a PUT, or
@@ -158,6 +159,10 @@ class RequestExecutor
         ];
         if ($request->getProxyUri()) {
             $curlOptions[CURLOPT_PROXY] = $request->getProxyUri();
+        }
+
+        if ($request->getTimeout() !== null) {
+            $curlOptions[CURLOPT_TIMEOUT_MS] = round($request->getTimeout() * self::MILLISECONDS_IN_SECOND);
         }
         return $curlOptions;
     }

--- a/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
@@ -54,7 +54,14 @@ class RequestFactory
         $url = trim($this->config->getBaseUri(), '/') . '/' . $requestContext->getPath();
         $message = $this->serializer->serializeRequest($requestContext);
         $headers = $this->buildHeaders($requestContext);
-        return new Request($url, $message, $headers, $this->config->getProxyUri());
+
+        return new Request(
+            $url,
+            $message,
+            $headers,
+            $this->config->getProxyUri(),
+            $requestContext->getTimeout()
+        );
     }
 
     /**

--- a/src/Grphp/Client/Strategy/H2Proxy/Strategy.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/Strategy.php
@@ -19,7 +19,6 @@ declare(strict_types = 1);
 
 namespace Grphp\Client\Strategy\H2Proxy;
 
-use Grphp\Client\ErrorStatus;
 use Grphp\Client\Error\Status;
 use Grphp\Client\Request as ClientRequest;
 use Grphp\Client\Response as ClientResponse;

--- a/tests/Unit/Grphp/Client/ErrorTest.php
+++ b/tests/Unit/Grphp/Client/ErrorTest.php
@@ -45,8 +45,10 @@ final class ErrorTest extends TestCase
         $this->client = new \Grphp\Client(\Grphp\Test\ThingsClient::class, $this->clientConfig);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->buildClient([
             'error_serializer' => \Grphp\Serializers\Errors\Json::class,
         ]);

--- a/tests/Unit/Grphp/Client/Interceptors/LinkerD/ContextPropagationTest.php
+++ b/tests/Unit/Grphp/Client/Interceptors/LinkerD/ContextPropagationTest.php
@@ -31,8 +31,10 @@ final class ContextPropagationTest extends TestCase
     /** @var ContextPropagation $interceptor */
     protected $interceptor;
 
-    public function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->interceptor = new ContextPropagation();
     }
 

--- a/tests/Unit/Grphp/Client/RequestTest.php
+++ b/tests/Unit/Grphp/Client/RequestTest.php
@@ -129,4 +129,20 @@ final class RequestTest extends TestCase
         static::assertInstanceOf(Response::class, $response);
         static::assertEquals($responseMessage, $response->getResponse());
     }
+
+    public function testGetTimeoutReturnsNullIfNoTimeoutSpecified()
+    {
+        $request = $this->buildRequest();
+
+        $this->assertSame(null, $request->getTimeout());
+    }
+
+    public function testGetTimeoutReturnsTimeoutFromOptions()
+    {
+        $options = ['timeout' => 1.55];
+
+        $request = $this->buildRequest('GetThings', null, [], $options);
+
+        $this->assertSame(1.55, $request->getTimeout());
+    }
 }

--- a/tests/Unit/Grphp/Client/RequestTest.php
+++ b/tests/Unit/Grphp/Client/RequestTest.php
@@ -32,7 +32,7 @@ final class RequestTest extends TestCase
     private $config;
     private $clientProphecy;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->config = new Config();

--- a/tests/Unit/Grphp/Client/ResponseTest.php
+++ b/tests/Unit/Grphp/Client/ResponseTest.php
@@ -31,8 +31,10 @@ final class ResponseTest extends TestCase
     /** @var float */
     protected $elapsed;
 
-    public function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $thing = new \Grphp\Test\Thing();
         $thing->setId(1234);
         $thing->setName('Test');

--- a/tests/Unit/Grphp/Client/Strategy/Grpc/StrategyTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/Grpc/StrategyTest.php
@@ -42,7 +42,7 @@ final class StrategyTest extends TestCase
     /** @var Strategy */
     private $strategy;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->config = new Config();

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/RequestFactoryTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/RequestFactoryTest.php
@@ -126,6 +126,7 @@ final class RequestFactoryTest extends TestCase
         $requestContext->getMetadata()->willReturn([]);
         $requestContext->buildDeadline()->willReturn(0);
         $requestContext->getPath()->willReturn('/espresso.machine/PullDoubleShot');
+        $requestContext->getTimeout()->willReturn(null);
 
         $config->getProxyUri()->willReturn('')->shouldBeCalled();
 
@@ -148,12 +149,14 @@ final class RequestFactoryTest extends TestCase
         $requestContext->getMetadata()->willReturn([]);
         $requestContext->buildDeadline()->willReturn(0);
         $requestContext->getPath()->willReturn('/My.GRPC.Service/rpc');
+        $requestContext->getTimeout()->willReturn(0.15);
 
         $config->getProxyUri()->willReturn('127.0.0.1:1234')->shouldBeCalled();
 
         $subject = new RequestFactory($config->reveal(), $serializer->reveal());
 
         $request = $subject->build($requestContext->reveal());
-        static::assertEquals('127.0.0.1:1234', $request->getProxyUri());
+        $this->assertSame('127.0.0.1:1234', $request->getProxyUri());
+        $this->assertSame(0.15, $request->getTimeout());
     }
 }

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/RequestFactoryTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/RequestFactoryTest.php
@@ -50,7 +50,7 @@ final class RequestFactoryTest extends TestCase
         return new RequestContext($this->config, 'GetThing', $req, $clientProphecy->reveal(), $metadata, $options);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->config = new Config();

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/StrategyFactoryTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/StrategyFactoryTest.php
@@ -29,7 +29,7 @@ final class StrategyFactoryTest extends TestCase
     /** @var Config */
     private $h2Config;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->h2Config = new Config();

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/StrategyTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/StrategyTest.php
@@ -46,9 +46,10 @@ final class StrategyTest extends TestCase
     private $responseHeaders;
     private $responseStatus;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
+
         $this->executorProphecy = $this->prophesize(RequestExecutor::class);
 
         $this->config = new \Grphp\Client\Config();

--- a/tests/Unit/Grphp/Serializers/Errors/JsonTest.php
+++ b/tests/Unit/Grphp/Serializers/Errors/JsonTest.php
@@ -24,8 +24,10 @@ final class JsonTest extends TestCase
     /** @var Json $serializer */
     protected $serializer;
 
-    public function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->serializer = new Json();
     }
 


### PR DESCRIPTION
Before this change, the client relied solely upon the `deadline` that is sent to the gRPC server when using the HTTP proxy strategy.

With this change, the timeout will be set for the cURL client and this will ensure that the client can also close the connection should the server be unable to respond for some reason.

Additionally, enabled support for PHPUnit 8.0+ and fixed some deprecations and warnings.