### PR TITLE
Add ability to configure content type in H2Proxy strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 Changelog for grphp.
 
-h3. 0.5.1
+### Pending Release
+
+* Add the ability to configure the content-type header for requests using the H2Proxy strategy 
+
+### 0.5.1
 
 * Suppress "expect: 100-continue" header on outbound cURL requests for the H2Proxy strategy
 
-h3. 0.5.0
+### 0.5.0
 
 * Introduce new strategy patterns for communicating out to services, allowing either gRPC or H2Proxy for the client
 * Adds H2Proxy strategy for utilizing nghttpx to proxy H1 requests into H2 gRPC requests without need of the PHP C
@@ -13,48 +17,48 @@ extension
 * Adds a new client request object for encapsulating contextual information about the outgoing request
 * Adds new Header and HeaderCollection classes for representing HTTP headers both outbound and inbound  
 
-h3. 0.4.0
+### 0.4.0
 
 * Update to gRPC 1.9.x
 * Get off BC gRPC fork now that root SSL memory leak issue is fixed
 
-h3. 0.3.9
+### 0.3.9
 
 * Ensure that client stubs are not instantiated on construction, but rather lazily loaded on first service call
 
-h3. 0.3.2
+### 0.3.2
 
 * Ensure LinkerD interceptor pulls from SERVER and REQUEST
 * Ensure LinkerD interceptor handles transformation of context keys
 
-h3. 0.3.1
+### 0.3.1
 
 * Fix timer interceptor to properly report in ms
 * Add more unit tests
 
-h3. 0.3.0
+### 0.3.0
 
 * Improved interceptor config support, useDefaultInterceptors config option
 
-h3. 0.2.1
+### 0.2.1
 
 * Allow client stub to be accessible to interceptors
 * Add isSuccess to \Grphp\Client\Response
 
-h3. 0.2.0
+### 0.2.0
 
 * Add LinkerD context propagation interceptor
 * Add interceptor options
 * Set l5d + timer interceptors to be default
 
-h3. 0.1.1
+### 0.1.1
 
 * Fix channel issue for gRPC 1.3.2
 
-h3. 0.1.0
+### 0.1.0
 
 * Rename instrumentors to interceptors
 
-h3. 0.0.3
+### 0.0.3
 
 * Rollback to gRPC 1.3.2 until https://github.com/grpc/grpc/issues/11711 is fixed

--- a/src/Grphp/Client/Strategy/H2Proxy/Config.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/Config.php
@@ -29,6 +29,8 @@ class Config
     const DEFAULT_ADDRESS = 'http://0.0.0.0:3000';
     /** @var int The default timeout for connecting to the nghttpx proxy and resolving its result */
     const DEFAULT_TIMEOUT = 15;
+    /** @var string The default content type to send on client requests */
+    const DEFAULT_CONTENT_TYPE = 'application/grpc+proto';
 
     /** @var string */
     private $baseUri;
@@ -39,19 +41,25 @@ class Config
     /** @var int */
     private $timeout;
 
+    /** @var string */
+    private $contentType;
+
     /**
      * @param string $baseUri The address and port of the nghttpx proxy
      * @param int $timeout The timeout to connect to the proxy, in seconds
      * @param string $proxyUri
+     * @param string $contentType The content type to use when issuing requests through this strategy
      */
     public function __construct(
         string $baseUri = self::DEFAULT_ADDRESS,
         int $timeout = self::DEFAULT_TIMEOUT,
-        string $proxyUri = ''
+        string $proxyUri = '',
+        string $contentType = self::DEFAULT_CONTENT_TYPE
     ) {
         $this->baseUri = $this->validateBaseUri($baseUri);
         $this->timeout = $timeout;
         $this->proxyUri = $proxyUri;
+        $this->contentType = $contentType;
     }
 
     /**
@@ -89,5 +97,13 @@ class Config
     public function getProxyUri(): string
     {
         return $this->proxyUri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContentType(): string
+    {
+        return $this->contentType;
     }
 }

--- a/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
@@ -88,7 +88,7 @@ class RequestFactory
         }
         $headers->add('Upgrade', 'h2c');
         $headers->add('Connection', 'Upgrade');
-        $headers->add('Content-Type', 'application/grpc+proto');
+        $headers->add('Content-Type', $this->config->getContentType());
         $headers->add('TE', 'trailers');
         $headers->add('User-Agent', 'grphp/1.0.0');
         $headers->add('Grpc-Encoding', 'identity');

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/ConfigTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/ConfigTest.php
@@ -50,6 +50,18 @@ final class ConfigTest extends TestCase
         $this->assertSame(Config::DEFAULT_ADDRESS, $config->getBaseUri());
         $this->assertSame(Config::DEFAULT_TIMEOUT, $config->getTimeout());
         $this->assertSame('', $config->getProxyUri());
+        $this->assertSame(Config::DEFAULT_CONTENT_TYPE, $config->getContentType());
+    }
+
+    public function testConfigWithSetContentType()
+    {
+        $config = new Config(
+            Config::DEFAULT_ADDRESS,
+            Config::DEFAULT_TIMEOUT,
+            '',
+            'application/grpc'
+        );
+        $this->assertSame('application/grpc', $config->getContentType());
     }
 
     public function testConfigRejectsBaseUriWithoutAScheme()

--- a/tests/Unit/Grphp/Client/Strategy/H2Proxy/RequestFactoryTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/H2Proxy/RequestFactoryTest.php
@@ -123,6 +123,7 @@ final class RequestFactoryTest extends TestCase
         /** @var H2ProxyConfig|ObjectProphecy $config */
         $config = $this->prophesize(\Grphp\Client\Strategy\H2Proxy\Config::class);
         $config->getBaseUri()->willReturn('service.com:5678');
+        $config->getContentType()->willReturn(\Grphp\Client\Strategy\H2Proxy\Config::DEFAULT_CONTENT_TYPE);
 
         /** @var RequestContext|ObjectProphecy $requestContext */
         $requestContext = $this->prophesize(RequestContext::class);
@@ -146,6 +147,7 @@ final class RequestFactoryTest extends TestCase
         /** @var H2ProxyConfig|ObjectProphecy $config */
         $config = $this->prophesize(\Grphp\Client\Strategy\H2Proxy\Config::class);
         $config->getBaseUri()->willReturn('service.com:5678');
+        $config->getContentType()->willReturn(\Grphp\Client\Strategy\H2Proxy\Config::DEFAULT_CONTENT_TYPE);
 
         /** @var RequestContext|ObjectProphecy $requestContext */
         $requestContext = $this->prophesize(RequestContext::class);


### PR DESCRIPTION
## What?

grphp hard codes the content-type to application/grpc+proto for nghttpx purposes. 

In order to allow requests through Envoy, we need this to be configurable, so we can set it to the specification Envoy has: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_http1_bridge_filter - which is `application/grpc`.

This also fixes the CHANGELOG to use markdown properly.

----

@bigcommerce/husky @bigcommerce/infra-engineering 