### PR TITLE
Make Grphp\Client#getClient protected instead of private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for grphp.
 
 ### Pending Release
 
+### 3.1.1
+
+* Make Grphp\Client#getClient protected instead of private
+
 ### 3.1.0
 
 * Add the ability to configure the content-type header for requests using the H2Proxy strategy

--- a/src/Grphp/Client.php
+++ b/src/Grphp/Client.php
@@ -95,7 +95,7 @@ class Client
      * Lazy-load/instantiate client instance and appropriate channel credentials
      * @return \Grpc\BaseStub
      */
-    private function getClient()
+    protected function getClient()
     {
         if ($this->client === null) {
             $this->client = new $this->clientClassName($this->config->hostname, [


### PR DESCRIPTION
In order to enable extensibility of Grphp clients, allowing users to create custom client implementations, such as load balanced clients, we need to enable `getClient()` on the grphp client class to be protected, so that derived classes from `Grphp\Client` can modify its behavior. This does so.

----

@bigcommerce/platform-engineering @lord2800 @bigcommerce/infra-engineering @bigcommerce/husky 