### PR TITLE
Add Envoy strategy for using grphp with an Envoy proxy for gRPC egress communication

### DIFF
--- a/.php_cs.ruleset.xml
+++ b/.php_cs.ruleset.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="grphp phpcs">
+    <description>grphp phpcs custom standard to ignore grpc stubs</description>
+    <rule ref="PSR2">
+        <exclude-pattern>grpc.stubs.php</exclude-pattern>
+    </rule>
+    <rule ref="PSR1.Files.SideEffects">
+        <exclude-pattern>Client.php</exclude-pattern>
+    </rule>
+</ruleset>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for grphp.
 
 ### Pending Release
 
+* Add Envoy strategy for using grphp with an Envoy proxy for gRPC egress communication
+
 ### 3.1.1
 
 * Make Grphp\Client#getClient protected instead of private

--- a/README.md
+++ b/README.md
@@ -68,16 +68,33 @@ You can use and configure the proxy strategy like so, assuming we have a nghttpx
 on port 3000:
 
 ```php
-
-$shovelConfig = new Grphp\Client\Strategy\Shovel\Config('http://0.0.0.0:3000', 15);
-$shovelStrategyFactory = new Grphp\Client\Strategy\Shovel\StrategyFactory($shovelConfig);
+$proxyConfig = new Grphp\Client\Strategy\H2Proxy\Config('http://0.0.0.0:3000', 15);
+$proxyStrategyFactory = new Grphp\Client\Strategy\H2Proxy\StrategyFactory($proxyConfig);
 $config = new Grphp\Client\Config([
-    'strategy' => $shovelStrategyFactory->build(),
+    'strategy' => $proxyStrategyFactory->build(),
 ]);
 ```
 
 This sets the proxy client to also utilize a timeout of 15 seconds. This setup is configurable per-client, so you can
-adjust these settings - and the strategy - on a service-by-service basis. 
+adjust these settings - and the strategy - on a service-by-service basis.
+
+### Envoy Strategy
+
+The Envoy strategy uses [Envoy](https://www.envoyproxy.io/) as an HTTP/1.1 bridge for gRPC egress traffic. It 
+automatically serializes messages and buffers requests to handle the response trailers. More can be read about the
+[Envoy bridge here](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_http1_bridge_filter).
+
+```php
+// Connect to Envoy at 127.0.0.1:19000
+$envoyConfig = new Grphp\Client\Strategy\Envoy\Config('127.0.0.1', 19000, 2);
+$envoyStrategyFactory = new Grphp\Client\Strategy\Envoy\StrategyFactory($envoyConfig);
+$config = new Grphp\Client\Config([
+    'strategy' => $envoyStrategyFactory->build(),
+]);
+```
+
+This sets the proxy client to also utilize a timeout of 2 seconds. This setup is configurable per-client, so you can
+adjust these settings - and the strategy - on a service-by-service basis.
 
 ## Authentication
 

--- a/script/test
+++ b/script/test
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+echo "Running test suite..."
+
+echo "Running composer install..."
+composer install
+
+echo "Running PHPCS code sniffer..."
+./vendor/bin/phpcs --standard=.php_cs.ruleset.xml src
+
+echo "Running CS fixer..."
+./vendor/bin/php-cs-fixer fix --diff --dry-run -v
+
+echo "Running phpunit..."
+./vendor/bin/phpunit --configuration phpunit.xml.dist
+
+echo "Done!"

--- a/src/Grphp/Client.php
+++ b/src/Grphp/Client.php
@@ -27,8 +27,8 @@ use Grphp\Client\Interceptors\Timer as TimerInterceptor;
 use Grphp\Client\Interceptors\LinkerD\ContextPropagation as LinkerDContextInterceptor;
 use Grphp\Client\Request;
 use Grphp\Client\Response;
+use Grphp\Client\Strategy\Grpc\Strategy as GrpcStrategy;
 use Grphp\Client\Strategy\H2Proxy\Config as H2ProxyConfig;
-use Grphp\Client\Strategy\H2Proxy\Strategy as H2ProxyStrategy;
 use Grphp\Client\Strategy\H2Proxy\StrategyFactory as H2ProxyStrategyFactory;
 
 /**
@@ -192,9 +192,9 @@ class Client
     }
 
     /**
-     * Load stubs and use h2proxy strategy if the C extension is not loaded
+     * Load stubs and use h2proxy strategy if the C extension is not loaded and grpc strategy is set
      */
-    private function validateAndDetermineStrategy()
+    private function validateAndDetermineStrategy(): void
     {
         if (extension_loaded('grpc')) {
             return;
@@ -202,9 +202,9 @@ class Client
 
         require_once dirname(__FILE__) . '/grpc.stubs.php';
 
-        // force the h2proxy strategy
+        // if grpc extension is not loaded but is set to be used, force the h2proxy strategy instead
         $strategy = $this->config->getStrategy();
-        if (!is_a($strategy, H2ProxyStrategy::class)) {
+        if (is_a($strategy, GrpcStrategy::class)) {
             $h2ProxyConfig = new H2ProxyConfig();
             $h2ProxyStrategy = (new H2ProxyStrategyFactory($h2ProxyConfig))->build();
             $this->config->setStrategy($h2ProxyStrategy);

--- a/src/Grphp/Client/HeaderCollection.php
+++ b/src/Grphp/Client/HeaderCollection.php
@@ -28,6 +28,30 @@ class HeaderCollection
     protected $headers = [];
 
     /**
+     * @param Request $request
+     * @return static
+     */
+    public static function fromRequest(Request $request): self
+    {
+        $headers = new self();
+        $metadata = $request->getMetadata();
+        foreach ($metadata as $k => $v) {
+            if (is_string($v)) {
+                $headers->add($k, $v);
+            } else {
+                foreach ($v as $v2) {
+                    $headers->add($k, $v2);
+                }
+            }
+        }
+        $deadline = $request->buildDeadline();
+        if (!empty($deadline)) {
+            $headers->add('Deadline', strval($deadline));
+        }
+        return $headers;
+    }
+
+    /**
      * Add a value to a header
      *
      * @param string $name The name of the header

--- a/src/Grphp/Client/Strategy/Envoy/Config.php
+++ b/src/Grphp/Client/Strategy/Envoy/Config.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+/**
+ * Configuration for the Envoy strategy
+ */
+class Config
+{
+    /** @var string The default hostname of the Envoy proxy */
+    const DEFAULT_ENVOY_HOST = '127.0.0.1';
+    /** @var int The default port of the Envoy proxy */
+    const DEFAULT_ENVOY_PORT = 19001;
+    /** @var int The default timeout for connecting to Envoy and resolving its result */
+    const DEFAULT_TIMEOUT = 15;
+    /** @var string The default content type to send on client requests */
+    const DEFAULT_CONTENT_TYPE = 'application/grpc';
+    /** @var string User agent to use when sending cURL requests to Envoy proxy */
+    const DEFAULT_USER_AGENT = 'grphp/1.0.0';
+
+    /** @var string */
+    private $address;
+
+    /** @var int */
+    private $timeout;
+
+    /** @var string */
+    private $contentType;
+
+    /** @var string */
+    private $userAgent;
+
+    /**
+     * @param string|null $host The address of the Envoy proxy
+     * @param int|null $port The port the Envoy proxy is receiving ingress on
+     * @param int|null $timeout The timeout to connect to the proxy, in seconds
+     * @param string|null $contentType The content type to use when issuing requests through this strategy
+     * @param string|null $userAgent The user agent to use in egress requests to Envoy
+     */
+    public function __construct(
+        string $host = self::DEFAULT_ENVOY_HOST,
+        int $port = self::DEFAULT_ENVOY_PORT,
+        int $timeout = self::DEFAULT_TIMEOUT,
+        string $contentType = self::DEFAULT_CONTENT_TYPE,
+        string $userAgent = self::DEFAULT_USER_AGENT
+    ) {
+        $this->address = $this->buildAddress($host, $port);
+        $this->timeout = $timeout;
+        $this->contentType = $contentType;
+        $this->userAgent = $userAgent;
+    }
+
+    /**
+     * @param string|null $host
+     * @param int|null $port
+     * @return string
+     */
+    private function buildAddress(string $host, int $port): string
+    {
+        $host = $host ?: static::DEFAULT_ENVOY_HOST;
+        $port = $port ?: static::DEFAULT_ENVOY_PORT;
+        return 'http://' . $host . ':' . $port;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContentType(): string
+    {
+        return $this->contentType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserAgent(): string
+    {
+        return $this->userAgent;
+    }
+}

--- a/src/Grphp/Client/Strategy/Envoy/Request.php
+++ b/src/Grphp/Client/Strategy/Envoy/Request.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+declare(strict_types = 1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+use Grphp\Client\HeaderCollection;
+
+/**
+ * Represents a request being sent through Envoy by grphp
+ */
+class Request
+{
+    /** @var string */
+    private $url;
+    /** @var string */
+    private $message;
+    /** @var HeaderCollection */
+    private $headers;
+    /** @var float|null */
+    private $timeout;
+
+    /**
+     * @param string $url The URL Envoy runs on
+     * @param string $message The binary serialized protobuf message
+     * @param HeaderCollection $headers Headers to send
+     * @param float|null $timeout
+     */
+    public function __construct(
+        string $url,
+        string $message,
+        HeaderCollection $headers,
+        ?float $timeout = null
+    ) {
+        $this->url = $url;
+        $this->message = $message;
+        $this->headers = $headers;
+        $this->timeout = $timeout;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return HeaderCollection
+     */
+    public function getHeaders(): HeaderCollection
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getTimeout(): ?float
+    {
+        return $this->timeout;
+    }
+}

--- a/src/Grphp/Client/Strategy/Envoy/RequestException.php
+++ b/src/Grphp/Client/Strategy/Envoy/RequestException.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+declare(strict_types = 1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+use Exception;
+use Grphp\Client\Error\Status;
+use Grphp\Client\HeaderCollection;
+use Throwable;
+
+/**
+ * Represents a failed request that stores the body response, headers, and error message
+ */
+class RequestException extends Exception
+{
+    /** @var string */
+    protected $body;
+    /** @var HeaderCollection */
+    protected $headers;
+
+    /**
+     * @param string $body
+     * @param HeaderCollection $headers
+     * @param Throwable|null $previous
+     */
+    public function __construct(string $body, HeaderCollection $headers, Throwable $previous = null)
+    {
+        $this->body = $body;
+        $this->headers = $headers;
+
+        parent::__construct($this->getErrorMessage(), $this->getStatusCode(), $previous);
+    }
+
+    /**
+     * Get the gRPC status code for this request
+     *
+     * @return integer
+     */
+    private function getStatusCode(): int
+    {
+        $header = $this->headers->get('grpc-status');
+        return $header ? (int)$header->getFirstValue() : Status::CODE_UNKNOWN;
+    }
+
+    /**
+     * Get the gRPC error message for this failed request
+     *
+     * @return string
+     */
+    public function getErrorMessage(): string
+    {
+        $header = $this->headers->get('grpc-message');
+        return $header ? $header->getFirstValue() : substr($this->body, 0, 255);
+    }
+
+    /**
+     * Return the headers sent in this failed request
+     *
+     * @return HeaderCollection
+     */
+    public function getHeaders(): HeaderCollection
+    {
+        return $this->headers;
+    }
+}

--- a/src/Grphp/Client/Strategy/Envoy/RequestExecutor.php
+++ b/src/Grphp/Client/Strategy/Envoy/RequestExecutor.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+use Grphp\Client\HeaderCollection;
+
+/**
+ * Execute egress requests to Envoy via cURL
+ */
+class RequestExecutor
+{
+    const GRPC_BINARY_ENCODED_METADATA_POSTFIX = '-bin';
+    const GRPC_CONTENT_TYPE = 'application/grpc';
+    const GRPC_ENCODING = 'identity';
+    const GRPC_STATUS_HEADER = 'grpc-status';
+    const GRPC_STATUS_OK = '0';
+    const GRPHP_USER_AGENT = 'grphp/1.0.0';
+    const PACK_ARGS = '\0';
+    const PACK_FORMAT = 'cN';
+    const PACK_START = 5;
+
+    private const UNCOMPRESSED_EMPTY_GRPC_MESSAGE = "\x00\x00\x00\x00\x00";
+    private const COMPRESSED_EMPTY_GRPC_MESSAGE = "\x01\x00\x00\x00\x00";
+    private const MILLISECONDS_IN_SECOND = 1000;
+
+    /**
+     * curl automatically sets "expect: 100-continue" header, if either
+     * - the request is a PUT, or
+     * - the request is a POST and the data size is larger than 1024 bytes
+     *
+     * the header is not always correctly handled by servers,
+     * especially http2 based; curl won't send it, if the following header is set
+     */
+    const EXPECT_CONTINUE_DISABLING_HEADER = 'expect:';
+
+    /**
+     * @param Request $request
+     * @return Response
+     * @throws RequestException
+     */
+    public function send(Request $request): Response
+    {
+        $payload = $this->buildPayload($request);
+        $responseHeaders = new HeaderCollection();
+
+        $ch = curl_init($request->getUrl());
+        curl_setopt_array($ch, $this->getCurlOptions($request, $payload));
+        curl_setopt(
+            $ch,
+            CURLOPT_HEADERFUNCTION,
+            function ($ch, $header) use ($responseHeaders) {
+                $vs = explode(':', $header, 2);
+                if (!empty($vs) && isset($vs[1])) {
+                    $k = $vs[0];
+                    $v = $vs[1];
+                    if (strpos(strtolower($k), static::GRPC_BINARY_ENCODED_METADATA_POSTFIX) > 0) {
+                        // need to base64 decode binary encoded metadata here, since gRPC normally does this for us
+                        $v = base64_decode($v);
+                    } else {
+                        $v = trim($v);// otherwise, we need to trim the output
+                    }
+                    $responseHeaders->add($k, $v);
+                }
+                return strlen($header);
+            }
+        );
+
+        $response = curl_exec($ch);
+        if (curl_errno($ch)) {
+            throw new RequestException(curl_error($ch), $responseHeaders);
+        }
+
+        $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        curl_close($ch);
+
+        return $this->handleResponse($responseHeaders, substr($response, $headerSize));
+    }
+
+    /**
+     * @param HeaderCollection $responseHeaders
+     * @param string $body
+     * @return Response
+     * @throws RequestException
+     */
+    private function handleResponse(HeaderCollection $responseHeaders, string $body): Response
+    {
+        $header = $responseHeaders->get(static::GRPC_STATUS_HEADER);
+        if (!$header) {
+            $message = $body;
+            if ($this->isEmptyMessage($message)) {
+                $message = "Missing grpc-status header";
+            }
+
+            throw new RequestException($message, $responseHeaders);
+        }
+
+        if ($header->getFirstValue() != static::GRPC_STATUS_OK) {
+            throw new RequestException("gRPC status: {$header->getFirstValue()}", $responseHeaders);
+        }
+
+        if (!empty($body)) {
+            $body = substr($body, static::PACK_START); // strip off pack
+        }
+
+        return new Response($body, $responseHeaders);
+    }
+
+    /**
+     * @param string $body
+     * @return bool
+     */
+    private function isEmptyMessage(string $body): bool
+    {
+        return !$body ||
+            $body === static::COMPRESSED_EMPTY_GRPC_MESSAGE ||
+            $body === static::UNCOMPRESSED_EMPTY_GRPC_MESSAGE;
+    }
+
+    /**
+     * @param Request $request
+     * @return string
+     */
+    private function buildPayload(Request $request): string
+    {
+        $message = $request->getMessage();
+        return pack(static::PACK_FORMAT, static::PACK_ARGS, strlen($message)) . $message;
+    }
+
+    /**
+     * @param Request $request
+     * @param string $payload
+     * @return array
+     */
+    private function getCurlOptions(Request $request, string $payload): array
+    {
+        $headers = $request->getHeaders()->compress();
+        $headers[] = self::EXPECT_CONTINUE_DISABLING_HEADER;
+        $curlOptions = [
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CUSTOMREQUEST => 'POST',
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_HEADER => true,
+            CURLOPT_USERAGENT => static::GRPHP_USER_AGENT,
+            CURLOPT_ENCODING => static::GRPC_ENCODING,
+            CURLOPT_CONTENT_TYPE => static::GRPC_CONTENT_TYPE
+        ];
+        if ($request->getTimeout() !== null) {
+            $curlOptions[CURLOPT_TIMEOUT_MS] = round($request->getTimeout() * self::MILLISECONDS_IN_SECOND);
+        }
+        return $curlOptions;
+    }
+}

--- a/src/Grphp/Client/Strategy/Envoy/Response.php
+++ b/src/Grphp/Client/Strategy/Envoy/Response.php
@@ -15,8 +15,45 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-$_ENV['TEST_MODE'] = 1;
-error_reporting(E_ALL | E_STRICT);
-date_default_timezone_set('UTC');
-require dirname(__DIR__) . '/tests/Support/Client.php';
-require dirname(__DIR__) . '/tests/Support/TestInterceptors.php';
+declare(strict_types = 1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+use Grphp\Client\HeaderCollection;
+
+/**
+ * Response from Envoy
+ */
+class Response
+{
+    /** @var string */
+    private $body;
+    /** @var array */
+    private $headers;
+
+    /**
+     * @param string $body
+     * @param HeaderCollection $headers
+     */
+    public function __construct(string $body, HeaderCollection $headers)
+    {
+        $this->body = $body;
+        $this->headers = $headers;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    /**
+     * @return HeaderCollection
+     */
+    public function getHeaders(): HeaderCollection
+    {
+        return $this->headers;
+    }
+}

--- a/src/Grphp/Client/Strategy/Envoy/Strategy.php
+++ b/src/Grphp/Client/Strategy/Envoy/Strategy.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+use Grphp\Client\Error as ClientError;
+use Grphp\Client\Error\Status;
+use Grphp\Client\Response as ClientResponse;
+use Grphp\Client\Request as ClientRequest;
+use Grphp\Client\FailedResponseClassLookupException;
+use Grphp\Client\Strategy\StrategyInterface;
+use Grphp\Protobuf\SerializationException;
+use Grphp\Protobuf\Serializer;
+
+/**
+ * Strategy for using Envoy for outbound gRPC requests
+ */
+class Strategy implements StrategyInterface
+{
+    /** @var RequestExecutor $requestExecutor */
+    private $requestExecutor;
+    /** @var RequestFactory $requestFactory */
+    private $requestFactory;
+    /** @var Serializer $serializer */
+    private $serializer;
+
+    /**
+     * @param Serializer $serializer
+     * @param RequestFactory $requestFactory
+     * @param RequestExecutor $requestExecutor
+     */
+    public function __construct(
+        Serializer $serializer,
+        RequestFactory $requestFactory,
+        RequestExecutor $requestExecutor
+    ) {
+        $this->serializer = $serializer;
+        $this->requestFactory = $requestFactory;
+        $this->requestExecutor = $requestExecutor;
+    }
+
+    /**
+     * @param ClientRequest $request
+     * @return ClientResponse
+     * @throws FailedResponseClassLookupException
+     * @throws SerializationException
+     * @throws ClientError
+     */
+    public function execute(ClientRequest $request): ClientResponse
+    {
+        $response = null;
+        $proxyRequest = $this->requestFactory->build($request);
+        try {
+            $response = $this->requestExecutor->send($proxyRequest);
+            return $this->handleSuccess($request, $response);
+        } catch (RequestException $e) {
+            $message = "gRPC call `{$request->getPath()}` failed with `{$e->getMessage()}`";
+            $request->fail(new Status($e->getCode(), $message, $e->getHeaders()));
+        }
+        return $this->handleSuccess($request, $response);
+    }
+
+    /**
+     * @param ClientRequest $clientRequest
+     * @param Response $response
+     * @return ClientResponse
+     * @throws FailedResponseClassLookupException
+     * @throws SerializationException
+     */
+    private function handleSuccess(ClientRequest $clientRequest, Response $response): ClientResponse
+    {
+        $responseMessage = $this->serializer->deserialize(
+            $response->getBody(),
+            $clientRequest->getExpectedResponseMessageClass()
+        );
+
+        $status = new Status(Status::CODE_OK, '', $response->getHeaders());
+        return $clientRequest->succeed($responseMessage, $status);
+    }
+}

--- a/src/Grphp/Client/Strategy/Envoy/StrategyFactory.php
+++ b/src/Grphp/Client/Strategy/Envoy/StrategyFactory.php
@@ -15,8 +15,38 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-$_ENV['TEST_MODE'] = 1;
-error_reporting(E_ALL | E_STRICT);
-date_default_timezone_set('UTC');
-require dirname(__DIR__) . '/tests/Support/Client.php';
-require dirname(__DIR__) . '/tests/Support/TestInterceptors.php';
+declare(strict_types = 1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+use Grphp\Protobuf\Serializer;
+
+/**
+ * Builds Envoy strategies and its dependency graph from the Envoy config
+ */
+class StrategyFactory
+{
+    /** @var Config */
+    private $config;
+
+    /**
+     * @param Config $config
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return Strategy
+     */
+    public function build(): Strategy
+    {
+        $serializer = new Serializer();
+        return new Strategy(
+            $serializer,
+            new RequestFactory($this->config, $serializer),
+            new RequestExecutor()
+        );
+    }
+}

--- a/tests/Unit/Grphp/Client/Strategy/Envoy/ConfigTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/Envoy/ConfigTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Grphp\Client\Strategy\Envoy;
+
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    public function testConfigWithTimeout()
+    {
+        $host = 'localhost';
+        $port = 1234;
+        $timeout = 5;
+
+        $config = new Config($host, $port, $timeout);
+
+        $this->assertSame("http://$host:$port", $config->getAddress());
+        $this->assertSame($timeout, $config->getTimeout());
+    }
+
+    public function testConfigWithNoTimeout()
+    {
+        $host = 'my.service';
+        $port = 5000;
+        $timeout = 0;
+
+        $config = new Config($host, $port, $timeout);
+
+        $this->assertSame("http://$host:$port", $config->getAddress());
+        $this->assertSame(0, $config->getTimeout());
+    }
+
+    public function testConfigWithDefaults()
+    {
+        $config = new Config();
+        $this->assertSame('http://' . Config::DEFAULT_ENVOY_HOST . ':' . Config::DEFAULT_ENVOY_PORT, $config->getAddress());
+        $this->assertSame(Config::DEFAULT_TIMEOUT, $config->getTimeout());
+        $this->assertSame(Config::DEFAULT_CONTENT_TYPE, $config->getContentType());
+        $this->assertSame(Config::DEFAULT_USER_AGENT, $config->getUserAgent());
+    }
+
+    public function testConfigWithSetContentType()
+    {
+        $config = new Config(
+            Config::DEFAULT_ENVOY_HOST,
+            Config::DEFAULT_ENVOY_PORT,
+            Config::DEFAULT_TIMEOUT,
+            'application/grpc2'
+        );
+        $this->assertSame('application/grpc2', $config->getContentType());
+    }
+
+    public function testConfigWithSetUserAgent()
+    {
+        $config = new Config(
+            Config::DEFAULT_ENVOY_HOST,
+            Config::DEFAULT_ENVOY_PORT,
+            Config::DEFAULT_TIMEOUT,
+            Config::DEFAULT_USER_AGENT,
+            'foobar:1.0.0'
+        );
+        $this->assertSame('foobar:1.0.0', $config->getUserAgent());
+    }
+}

--- a/tests/Unit/Grphp/Client/Strategy/Envoy/RequestFactoryTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/Envoy/RequestFactoryTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+use Grphp\Client\Config;
+use Grphp\Client\Request as RequestContext;
+use Grphp\Client\Strategy\Envoy\Config as EnvoyConfig;
+use Grphp\Protobuf\Serializer;
+use Grphp\Test\GetThingReq;
+use Grphp\Test\ThingsClient;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+final class RequestFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @var Config */
+    private $config;
+
+    /** @var RequestFactory */
+    private $requestFactory;
+
+    public function buildRequest($req = null, array $metadata = [], array $options = [])
+    {
+        $req = $req ?: new GetThingReq();
+        $clientProphecy = $this->prophesize(ThingsClient::class);
+        return new RequestContext($this->config, 'GetThing', $req, $clientProphecy->reveal(), $metadata, $options);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->config = new Config();
+        $this->requestFactory = new RequestFactory(new EnvoyConfig(), new Serializer());
+    }
+
+    public function testBuild()
+    {
+        $requestContext = $this->buildRequest();
+        $httpRequest = $this->requestFactory->build($requestContext);
+        $this->assertInstanceOf(Request::class, $httpRequest);
+
+        $headers = $httpRequest->getHeaders();
+        $this->assertEquals('application/grpc', $headers->get('Content-Type')->getValuesAsString());
+        $this->assertEquals('grphp/1.0.0', $headers->get('User-Agent')->getValuesAsString());
+
+        $deadlineish = intval(microtime(true) + RequestContext::DEFAULT_TIMEOUT);
+        $this->assertEquals($deadlineish, intval($headers->get('Deadline')->getValuesAsString()));
+    }
+
+    public function testWithHeaders()
+    {
+        $requestContext = $this->buildRequest(
+            null,
+            [
+                'Foo' => 'bar',
+                'Array' => ['123', '456'],
+            ]
+        );
+        $request = $this->requestFactory->build($requestContext);
+        $this->assertInstanceOf(Request::class, $request);
+
+        $headers = $request->getHeaders();
+        $this->assertEquals('bar', $headers->get('Foo')->getValuesAsString());
+        $this->assertEquals('123,456', $headers->get('Array')->getValuesAsString());
+    }
+
+    public function testWithCustomDeadline()
+    {
+        $newDeadline = 5.2;
+
+        $requestContext = $this->buildRequest(
+            null,
+            [],
+            [
+                'timeout' => $newDeadline,
+            ]
+        );
+        $httpRequest = $this->requestFactory->build($requestContext);
+        $this->assertInstanceOf(Request::class, $httpRequest);
+
+        $deadlineish = intval(microtime(true) + $newDeadline);
+        $headers = $httpRequest->getHeaders();
+        $this->assertEquals($deadlineish, intval($headers->get('Deadline')->getValuesAsString()));
+    }
+}

--- a/tests/Unit/Grphp/Client/Strategy/Envoy/ResponseTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/Envoy/ResponseTest.php
@@ -15,8 +15,27 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-$_ENV['TEST_MODE'] = 1;
-error_reporting(E_ALL | E_STRICT);
-date_default_timezone_set('UTC');
-require dirname(__DIR__) . '/tests/Support/Client.php';
-require dirname(__DIR__) . '/tests/Support/TestInterceptors.php';
+declare(strict_types = 1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+use Grphp\Client\HeaderCollection;
+use PHPUnit\Framework\TestCase;
+
+final class ResponseTest extends TestCase
+{
+    public function testGetBody()
+    {
+        $body = 'fooooooo bar.';
+        $response = new Response($body, new HeaderCollection());
+        $this->assertEquals($body, $response->getBody());
+    }
+
+    public function testGetHeaders()
+    {
+        $headers = new HeaderCollection();
+        $headers->add('baz', 'baaaaaaz');
+        $response = new Response('', $headers);
+        $this->assertEquals($headers, $response->getHeaders());
+    }
+}

--- a/tests/Unit/Grphp/Client/Strategy/Envoy/StrategyFactoryTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/Envoy/StrategyFactoryTest.php
@@ -15,8 +15,20 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-$_ENV['TEST_MODE'] = 1;
-error_reporting(E_ALL | E_STRICT);
-date_default_timezone_set('UTC');
-require dirname(__DIR__) . '/tests/Support/Client.php';
-require dirname(__DIR__) . '/tests/Support/TestInterceptors.php';
+declare(strict_types = 1);
+
+namespace Grphp\Client\Strategy\Envoy;
+
+use Grphp\Client\Strategy\H2Proxy\Config;
+use Grphp\Client\Strategy\H2Proxy\Strategy;
+use Grphp\Client\Strategy\H2Proxy\StrategyFactory;
+use PHPUnit\Framework\TestCase;
+
+final class StrategyFactoryTest extends TestCase
+{
+    public function testBuild()
+    {
+        $factory = new StrategyFactory(new Config());
+        $this->assertInstanceOf(Strategy::class, $factory->build());
+    }
+}

--- a/tests/Unit/Grphp/Client/Strategy/Envoy/StrategyTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/Envoy/StrategyTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Grphp\Client\Strategy\Envoy;
+
+use Exception;
+use Grpc\UnaryCall;
+use Grphp\Client\Error;
+use Grphp\Client\Error\Status;
+use Grphp\Client\HeaderCollection;
+use Grphp\Client\Request;
+use Grphp\Client\Response;
+use Grphp\Client\Strategy\Envoy\Request as EnvoyRequest;
+use Grphp\Client\Strategy\Envoy\RequestException;
+use Grphp\Client\Strategy\Envoy\Response as EnvoyResponse;
+use Grphp\Protobuf\Serializer;
+use Grphp\Test\CallStatus;
+use Grphp\Test\GetThingReq;
+use Grphp\Test\GetThingResp;
+use Grphp\Test\ThingsClient;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+final class StrategyTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $executorProphecy;
+    private $config;
+    private $envoyConfig;
+    private $serializer;
+    private $requestFactory;
+    private $response;
+    private $responseStatus;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->executorProphecy = $this->prophesize(RequestExecutor::class);
+
+        $this->config = new \Grphp\Client\Config();
+        $this->serializer = new Serializer();
+        $this->requestFactory = new RequestFactory(new Config(), $this->serializer);
+        $responseHeaders = new HeaderCollection();
+        $this->responseStatus = new Status(Status::CODE_INTERNAL, 'FAIL', $responseHeaders);
+        $this->response = new EnvoyResponse('', $responseHeaders);
+    }
+
+    public function buildClientProphecy($req)
+    {
+        $resp = new GetThingResp();
+        $grpcStatus = new CallStatus(0, '', [
+            'foo' => ['bar']
+        ]);
+        $unaryProphecy = $this->prophesize(UnaryCall::class);
+        $unaryProphecy->wait()->willReturn([$resp, $grpcStatus]);
+        $clientProphecy = $this->prophesize(ThingsClient::class);
+        $clientProphecy->GetThing($req, [], [])->willReturn($unaryProphecy->reveal());
+        $clientProphecy->getExpectedResponseMessages()->willReturn([
+            'getThing' => '\Grphp\Test\GetThingResp',
+        ]);
+        return $clientProphecy;
+    }
+
+    public function buildClientRequest($clientProphecy, $req)
+    {
+        return new Request($this->config, 'GetThing', $req, $clientProphecy->reveal(), [], []);
+    }
+
+    public function testSuccessfulExecution()
+    {
+        $req = new GetThingReq();
+        $clientProphecy = $this->buildClientProphecy($req);
+        $clientRequest = $this->buildClientRequest($clientProphecy, $req);
+
+        $this->executorProphecy->send(Argument::type(EnvoyRequest::class))->willReturn($this->response);
+
+        $strategy = new Strategy($this->serializer, $this->requestFactory, $this->executorProphecy->reveal());
+        $response = $strategy->execute($clientRequest);
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
+    public function testFailedExecution()
+    {
+        $req = new GetThingReq();
+        $clientProphecy = $this->buildClientProphecy($req);
+        $clientRequest = $this->buildClientRequest($clientProphecy, $req);
+
+        $exception = new Error($this->config, $this->responseStatus);
+        $this->executorProphecy->send(Argument::type(EnvoyRequest::class))->willThrow($exception);
+
+        $strategy = new Strategy($this->serializer, $this->requestFactory, $this->executorProphecy->reveal());
+        $this->expectException(Error::class);
+        $strategy->execute($clientRequest);
+    }
+
+    public function testExecutePropagatesGrpcStatusCodeInTheException()
+    {
+        $headers = new HeaderCollection();
+        $headers->add('grpc-status', 16);
+        $headers->add('grpc-message', 'Unauthorized');
+        $body = 'Unauthorized, sorry!';
+
+        $request = $this->prophesize(Request::class);
+        $request->getPath()->willReturn("foo.barService/BazCall");
+
+        $config = $this->config;
+        $request->fail(Argument::allOf(Argument::Type(Status::class), Argument::which('getCode', 16)))
+            ->will(function (array $args) use ($config) {
+                throw new Error($config, $args[0]);
+            });
+
+        $h2Request = $this->prophesize(EnvoyRequest::class);
+
+        $serializer = $this->prophesize(Serializer::class);
+        $requestFactory = $this->prophesize(RequestFactory::class);
+        $requestFactory->build($request->reveal())->willReturn($h2Request->reveal());
+
+        $exception = new RequestException($body, $headers);
+
+        $this->executorProphecy->send($h2Request->reveal())->willThrow($exception);
+
+        $subject = new Strategy(
+            $serializer->reveal(),
+            $requestFactory->reveal(),
+            $this->executorProphecy->reveal()
+        );
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Unauthorized');
+        $this->expectExceptionCode(16);
+
+        $subject->execute($request->reveal());
+    }
+
+    public function testExecuteUsesUnknownCodeIfGrpcStatusHeaderIsMissing()
+    {
+        $headers = new HeaderCollection();
+        $body = 'Everything is on fire!';
+
+        $request = $this->prophesize(Request::class);
+        $request->getPath()->willReturn("foo.bar.bazService/GetThing");
+
+        $config = $this->config;
+        $request->fail(Argument::allOf(Argument::Type(Status::class), Argument::which('getCode', 2)))
+            ->will(function (array $args) use ($config) {
+                throw new Error($config, $args[0]);
+            });
+
+        $h2Request = $this->prophesize(EnvoyRequest::class);
+
+        $serializer = $this->prophesize(Serializer::class);
+        $requestFactory = $this->prophesize(RequestFactory::class);
+        $requestFactory->build($request->reveal())->willReturn($h2Request->reveal());
+
+        $exception = new RequestException($body, $headers);
+
+        $this->executorProphecy->send($h2Request->reveal())->willThrow($exception);
+
+        $subject = new Strategy(
+            $serializer->reveal(),
+            $requestFactory->reveal(),
+            $this->executorProphecy->reveal()
+        );
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Everything is on fire!');
+        $this->expectExceptionCode(2);
+
+        $subject->execute($request->reveal());
+    }
+}


### PR DESCRIPTION
## What?

Allows the use of Envoy as a separate egress strategy other than the available ones of gRPC and H2Proxy. This uses [Envoy's built-in HTTP/1.1 bridge filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_http1_bridge_filter) to automatically handle the 1.1->2 upgrade and buffer the response trailers.

Instead of adjusting the H2Proxy strategy (which is designed to work specifically with [nghttpx](https://nghttp2.org/documentation/nghttpx-howto.html)), it was preferred to create a new strategy instead, which allows more custom handling of the Envoy communication process.

----

@bigcommerce/platform-engineering @bigcommerce/infra-engineering @bigcommerce/husky 