### PR TITLE
Remove `CURLOPT_CONTENT_TYPE` and use  `CURLOPT_HTTPHEADER`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for grphp.
 
 ### Pending Release
 
+* `CURLOPT_CONTENT_TYPE` is deprecated; remove references and allow `CURLOPT_HTTPHEADER` to handle Content-Type headers
+
 ### 3.2.0
 
 * Add Envoy strategy for using grphp with an Envoy proxy for gRPC egress communication

--- a/src/Grphp/Client/Strategy/Envoy/RequestExecutor.php
+++ b/src/Grphp/Client/Strategy/Envoy/RequestExecutor.php
@@ -27,7 +27,6 @@ use Grphp\Client\HeaderCollection;
 class RequestExecutor
 {
     const GRPC_BINARY_ENCODED_METADATA_POSTFIX = '-bin';
-    const GRPC_CONTENT_TYPE = 'application/grpc';
     const GRPC_ENCODING = 'identity';
     const GRPC_STATUS_HEADER = 'grpc-status';
     const GRPC_STATUS_OK = '0';
@@ -160,8 +159,7 @@ class RequestExecutor
             CURLOPT_POSTFIELDS => $payload,
             CURLOPT_HEADER => true,
             CURLOPT_USERAGENT => static::GRPHP_USER_AGENT,
-            CURLOPT_ENCODING => static::GRPC_ENCODING,
-            CURLOPT_CONTENT_TYPE => static::GRPC_CONTENT_TYPE
+            CURLOPT_ENCODING => static::GRPC_ENCODING
         ];
         if ($request->getTimeout() !== null) {
             $curlOptions[CURLOPT_TIMEOUT_MS] = round($request->getTimeout() * self::MILLISECONDS_IN_SECOND);


### PR DESCRIPTION
Replaces `CURLOPT_CONTENT_TYPE` with delegation to the headers built by the Envoy strategy, which fixes:

```
[object] (Bigcommerce\\Infrastructure\\Exception\\ErrorException(code: 0): Use of undefined constant CURLOPT_CONTENT_TYPE - assumed 'CURLOPT_CONTENT_TYPE' (this will throw an Error in a future version of PHP)
E_WARNING: curl_setopt_array(): Array keys must be CURLOPT constants or equivalent integer values
```

---

@bigcommerce/infra-engineering @bigcommerce/husky @lord2800 @chrisboulton 