### PR TITLE
Add TE header for envoy requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for grphp.
 
 ### Pending Release
 
+### 3.2.2
+* Add header `TE: trailers` for envoy requests.
+
 ### 3.2.1
 
 * `CURLOPT_CONTENT_TYPE` is deprecated; remove references and allow `CURLOPT_HTTPHEADER` to handle Content-Type headers

--- a/src/Grphp/Client/Strategy/Envoy/RequestFactory.php
+++ b/src/Grphp/Client/Strategy/Envoy/RequestFactory.php
@@ -72,6 +72,8 @@ class RequestFactory
         $headers = HeaderCollection::fromRequest($clientRequest);
         $headers->add('Content-Type', $this->config->getContentType());
         $headers->add('User-Agent', $this->config->getUserAgent());
+        // @see https://github.com/grpc/grpc/blob/653ba62/doc/PROTOCOL-HTTP2.md?plain=1#L30
+        $headers->add('TE', 'trailers');
         return $headers;
     }
 }

--- a/tests/Unit/Grphp/Client/Strategy/Envoy/RequestFactoryTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/Envoy/RequestFactoryTest.php
@@ -61,6 +61,7 @@ final class RequestFactoryTest extends TestCase
         $headers = $httpRequest->getHeaders();
         $this->assertEquals('application/grpc', $headers->get('Content-Type')->getValuesAsString());
         $this->assertEquals('grphp/1.0.0', $headers->get('User-Agent')->getValuesAsString());
+        $this->assertSame('trailers', $headers->get('TE')->getValuesAsString());
 
         $deadlineish = intval(microtime(true) + RequestContext::DEFAULT_TIMEOUT);
         $this->assertEquals($deadlineish, intval($headers->get('Deadline')->getValuesAsString()));


### PR DESCRIPTION
This fixes the error `upstream connect error or disconnect/reset before headers. reset reason: remote reset`  when talking to some services via envoy.

ping @splittingred 

Note: It looks like CircleCI failed because of ssh key issue, but I don't have the permission to re-add CircleCI deploy key. @splittingred do you mind having a look at that too? Thanks!