### PR TITLE
interceptor improvements, drop php 7.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     parameters:
       php-version:
         type: string
-        default: 7.3-fpm
+        default: 7.4-fpm
     executor:
       name: php/php
       php-version: << parameters.php-version >>
@@ -27,7 +27,7 @@ jobs:
     parameters:
       php-version:
         type: string
-        default: 7.3-fpm
+        default: 7.4-fpm
     executor:
       name: php/php
       php-version: << parameters.php-version >>
@@ -44,7 +44,7 @@ jobs:
     parameters:
       php-version:
         type: string
-        default: 7.3-fpm
+        default: 7.4-fpm
     executor:
       name: php/php
       php-version: << parameters.php-version >>
@@ -65,12 +65,12 @@ workflows:
       - tests-unit:
           matrix:
             parameters:
-              php-version: [ "7.3-fpm", "7.4-fpm", "8.0-fpm" ]
+              php-version: [  "7.4-fpm", "8.0-fpm" ]
       - codesniffer:
           matrix:
             parameters:
-              php-version: [ "7.3-fpm", "7.4-fpm", "8.0-fpm" ]
+              php-version: [ "7.4-fpm", "8.0-fpm" ]
       - cs-fixer:
           matrix:
             parameters:
-              php-version: [ "7.3-fpm", "7.4-fpm", "8.0-fpm" ]
+              php-version: [  "7.4-fpm", "8.0-fpm" ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@ Changelog for grphp.
 
 ### Pending Release
 
+### 3.3.0
+
+* Add `getFullyQualifiedMethodName` and `getExpectedResponseMessageClass` to base Client Interceptor class
+* Drop PHP 7.3 support
+
 ### 3.2.2
+
 * Add header `TE: trailers` for envoy requests.
 
 ### 3.2.1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ preserving gRPC BadStatus codes
 * Client execution timings in responses
 * H2Proxy via nghttpx support that allows gRPC-based communication without the gRPC C libraries
 
-grphp currently has active support for gRPC 1.9.0, and requires PHP 7.0+ to run.
+grphp currently has active support for gRPC 1.9.0, and requires PHP 7.4+ to run.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "gRPC PHP Framework",
   "license": "MIT",
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "google/protobuf": "^3.7",
     "grpc/grpc": "^1.13"
   },

--- a/src/Grphp/Client.php
+++ b/src/Grphp/Client.php
@@ -42,11 +42,11 @@ class Client
     /** @var BaseStub $client */
     protected $client;
     /** @var Config $config */
-    protected $config;
+    protected Config $config;
     /** @var array<BaseInterceptor> $interceptors */
-    protected $interceptors = [];
+    protected array $interceptors = [];
     /** @var string */
-    private $clientClassName;
+    private string $clientClassName;
 
     /**
      * @param string $clientClassName

--- a/src/Grphp/Client/Interceptors/Base.php
+++ b/src/Grphp/Client/Interceptors/Base.php
@@ -15,7 +15,7 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Grphp\Client\Interceptors;
 
@@ -31,13 +31,13 @@ use Grphp\Client\Response;
 abstract class Base
 {
     /** @var array */
-    protected $options = [];
+    protected array $options = [];
     /** @var Message */
     protected $request;
     /** @var string */
-    protected $method;
+    protected string $method;
     /** @var array */
-    protected $metadata = [];
+    protected array $metadata = [];
     /** @var BaseStub */
     protected $stub;
 
@@ -73,6 +73,47 @@ abstract class Base
     }
 
     /**
+     * Gets the fully qualified method name, e.g. grphp.catalog.products/GetProduct
+     *
+     * @return string
+     * @throws StubNotFoundException
+     */
+    public function getFullyQualifiedMethodName(): string
+    {
+        $methodName = $this->getMethod();
+        $stub = $this->getStub();
+        if (empty($stub)) {
+            throw new StubNotFoundException("Stub not found for $methodName");
+        }
+
+        return $stub->getServiceName() . '/' . ucfirst($methodName);
+    }
+
+    /**
+     * Get the expected response protobuf message class
+     *
+     * @return string
+     * @throws StubNotFoundException
+     * @throws ResponseMessageLookupFailedException
+     */
+    public function getExpectedResponseMessageClass(): string
+    {
+        $methodName = $this->getMethod();
+        $stub = $this->getStub();
+        if (empty($stub)) {
+            throw new StubNotFoundException("Stub not found for $methodName");
+        }
+
+        $responseMessages = $stub->getExpectedResponseMessages();
+        $methodName = lcfirst($methodName);
+
+        if (!array_key_exists($methodName, $responseMessages)) {
+            throw new ResponseMessageLookupFailedException();
+        }
+        return $responseMessages[$methodName];
+    }
+
+    /**
      * @return string
      */
     public function getMethod(): string
@@ -84,7 +125,7 @@ abstract class Base
      * @param string $method
      * @return void
      */
-    public function setMethod(string &$method)
+    public function setMethod(string &$method): void
     {
         $this->method = $method;
     }
@@ -101,7 +142,7 @@ abstract class Base
      * @param array $metadata
      * @return void
      */
-    public function setMetadata(array &$metadata = [])
+    public function setMetadata(array &$metadata = []): void
     {
         $this->metadata = $metadata;
     }
@@ -118,7 +159,7 @@ abstract class Base
      * @param array $options
      * @return void
      */
-    public function setOptions(array &$options = [])
+    public function setOptions(array &$options = []): void
     {
         $this->options = $options;
     }
@@ -136,13 +177,13 @@ abstract class Base
     /**
      * @return BaseStub
      */
-    public function getStub(): BaseStub
+    public function getStub(): ?BaseStub
     {
         return $this->stub;
     }
 
     /**
-     * @param $stub
+     * @param BaseStub $stub
      */
     public function setStub(BaseStub &$stub)
     {

--- a/src/Grphp/Client/Interceptors/ResponseMessageLookupFailedException.php
+++ b/src/Grphp/Client/Interceptors/ResponseMessageLookupFailedException.php
@@ -15,25 +15,10 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace Grphp\Test;
+declare(strict_types=1);
 
-use Grphp\Client\Interceptors\Base;
+namespace Grphp\Client\Interceptors;
 
-class TestInterceptor extends Base
+class ResponseMessageLookupFailedException extends \Exception
 {
-    public function call(callable $callback)
-    {
-        return $callback();
-    }
-}
-
-class TestMetadataSetInterceptor extends Base
-{
-    public function call(callable $callback)
-    {
-        $md = $this->getMetadata();
-        $md['test'] = 'one';
-        $this->setMetadata($md);
-        return $callback();
-    }
 }

--- a/src/Grphp/Client/Interceptors/StubNotFoundException.php
+++ b/src/Grphp/Client/Interceptors/StubNotFoundException.php
@@ -15,25 +15,10 @@
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace Grphp\Test;
+declare(strict_types=1);
 
-use Grphp\Client\Interceptors\Base;
+namespace Grphp\Client\Interceptors;
 
-class TestInterceptor extends Base
+class StubNotFoundException extends \Exception
 {
-    public function call(callable $callback)
-    {
-        return $callback();
-    }
-}
-
-class TestMetadataSetInterceptor extends Base
-{
-    public function call(callable $callback)
-    {
-        $md = $this->getMetadata();
-        $md['test'] = 'one';
-        $this->setMetadata($md);
-        return $callback();
-    }
 }

--- a/tests/Support/Compiled/ThingsClient.php
+++ b/tests/Support/Compiled/ThingsClient.php
@@ -19,11 +19,16 @@ namespace Grphp\Test;
 
 class ThingsClient extends \Grpc\BaseStub
 {
-    public function getExpectedResponseMessages()
+    public function getExpectedResponseMessages(): array
     {
         return [
             'getThing' => '\Grphp\Test\GetThingResp',
         ];
+    }
+
+    public function getServiceName(): string
+    {
+        return 'grphp.test.Things';
     }
 
     protected $channel;
@@ -32,6 +37,7 @@ class ThingsClient extends \Grpc\BaseStub
      * @param string $hostname hostname
      * @param array $opts channel options
      * @param \Grpc\Channel $channel (optional) re-use channel object
+     * @throws \Exception
      */
     public function __construct($hostname, $opts, $channel = null)
     {

--- a/tests/Unit/Grphp/Client/Interceptors/BaseTest.php
+++ b/tests/Unit/Grphp/Client/Interceptors/BaseTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Unit\Grphp\Client\Interceptors;
+
+use Grphp\Client\Interceptors\ResponseMessageLookupFailedException;
+use Grphp\Client\Interceptors\StubNotFoundException;
+use Grphp\Test\GetThingReq;
+use Grphp\Test\TestInterceptor;
+use Grphp\Test\TestMetadataSetInterceptor;
+use Grphp\Test\ThingsClient;
+use PHPUnit\Framework\TestCase;
+
+class BaseTest extends TestCase
+{
+    public function testCall(): void
+    {
+        $interceptor = new TestInterceptor();
+        $result = $interceptor->call(function () {
+            return 42;
+        });
+        $this->assertSame($result, 42);
+    }
+
+    public function testMetadata(): void
+    {
+        $interceptor = new TestMetadataSetInterceptor();
+        $result = $interceptor->call(function () {
+            return 1;
+        });
+        $this->assertSame($result, 1);
+        $md = $interceptor->getMetadata();
+        $this->assertArrayHasKey('test', $md);
+        $this->assertEquals('one', $md['test']);
+    }
+
+    // Happy path for getting a FQN of the RPC in question
+    public function testGetExpectedResponseMessageClass(): void
+    {
+        $client = new ThingsClient('127.0.0.1:9000', [ 'credentials' => null ]);
+        $method = 'getThing';
+        $metadata = ['some' => 'value'];
+
+        $interceptor = new TestInterceptor();
+        $interceptor->setMethod($method);
+        $interceptor->setMetadata($metadata);
+        $interceptor->setStub($client);
+        $this->assertEquals('\Grphp\Test\GetThingResp', $interceptor->getExpectedResponseMessageClass());
+    }
+
+    // When then stub is not set for some wild reason
+    public function testGetExpectedResponseMessageClassWhenNoStub(): void
+    {
+        $this->expectException(StubNotFoundException::class);
+        $method = 'getThing';
+        $interceptor = new TestInterceptor();
+        $interceptor->setMethod($method);
+        $interceptor->getExpectedResponseMessageClass();
+    }
+
+    // When there is no matching response message
+    public function testGetExpectedResponseMessageClassWhenNoResponseMessageFound(): void
+    {
+        $this->expectException(ResponseMessageLookupFailedException::class);
+
+        $client = new ThingsClient('127.0.0.1:9000', [ 'credentials' => null ]);
+        $method = 'fakeGetThing';
+
+        $interceptor = new TestInterceptor();
+        $interceptor->setMethod($method);
+        $interceptor->setStub($client);
+        $interceptor->getExpectedResponseMessageClass();
+    }
+
+    // Get the full service name
+    public function testGetFullyQualifiedMethodName(): void
+    {
+        $requestMessage = new GetThingReq();
+        $requestMessage->setId(1);
+        $client = new ThingsClient('127.0.0.1:9000', [ 'credentials' => null ]);
+        $method = 'getThing';
+
+        $interceptor = new TestInterceptor();
+        $interceptor->setMethod($method);
+        $interceptor->setStub($client);
+        $this->assertEquals('grphp.test.Things/GetThing', $interceptor->getFullyQualifiedMethodName());
+    }
+
+    // When then stub is not set for some wild reason
+    public function testGetFullyQualifiedMethodNameWhenNoStub(): void
+    {
+        $this->expectException(StubNotFoundException::class);
+        $method = 'getThing';
+        $interceptor = new TestInterceptor();
+        $interceptor->setMethod($method);
+        $interceptor->getExpectedResponseMessageClass();
+    }
+}


### PR DESCRIPTION
## What?

* Add `getFullyQualifiedMethodName` and `getExpectedResponseMessageClass` to base Client Interceptor class
* Drop php 7.3 support (EOL)

