### PR TITLE
Use proxy client config timeout setting when request timeout is unset

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,6 +1,8 @@
 <?php
 
-return PhpCsFixer\Config::create()
+use PhpCsFixer\Config;
+
+return (new Config())
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->files()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog for grphp.
 ### 3.4.0
 
 * Set default request timeout to the proxy client config value.
+* Upgrade php-cs-fixer to v3.10.0.
 
 ### 3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for grphp.
 
 ### Pending Release
 
+### 3.4.0
+
+* Set default request timeout to the proxy client config value.
+
 ### 3.3.0
 
 * Add `getFullyQualifiedMethodName` and `getExpectedResponseMessageClass` to base Client Interceptor class

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "grpc/grpc": "^1.13"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.13",
+    "friendsofphp/php-cs-fixer": "^3",
     "phpunit/phpunit": "^9.0",
     "squizlabs/php_codesniffer": "3.*",
     "phpspec/prophecy-phpunit": "^2.0"

--- a/src/Grphp/Client/Strategy/Envoy/RequestFactory.php
+++ b/src/Grphp/Client/Strategy/Envoy/RequestFactory.php
@@ -29,8 +29,8 @@ use Grphp\Protobuf\Serializer;
  */
 class RequestFactory
 {
-    private Config $config;
-    private Serializer $serializer;
+    protected Config $config;
+    protected Serializer $serializer;
 
     public function __construct(Config $config, Serializer $serializer)
     {

--- a/src/Grphp/Client/Strategy/Envoy/RequestFactory.php
+++ b/src/Grphp/Client/Strategy/Envoy/RequestFactory.php
@@ -29,15 +29,9 @@ use Grphp\Protobuf\Serializer;
  */
 class RequestFactory
 {
-    /** @var Config $config */
-    protected $config;
-    /** @var Serializer $serializer */
-    protected $serializer;
+    private Config $config;
+    private Serializer $serializer;
 
-    /**
-     * @param Config $config
-     * @param Serializer $serializer
-     */
     public function __construct(Config $config, Serializer $serializer)
     {
         $this->config = $config;
@@ -59,14 +53,10 @@ class RequestFactory
             $url,
             $message,
             $headers,
-            $requestContext->getTimeout()
+            $requestContext->getTimeout() ?: $this->config->getTimeout()
         );
     }
 
-    /**
-     * @param ClientRequest $clientRequest
-     * @return HeaderCollection
-     */
     private function buildHeaders(ClientRequest $clientRequest): HeaderCollection
     {
         $headers = HeaderCollection::fromRequest($clientRequest);

--- a/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestFactory.php
@@ -29,15 +29,9 @@ use Grphp\Protobuf\Serializer;
  */
 class RequestFactory
 {
-    /** @var Config */
-    private $config;
-    /** @var Serializer */
-    private $serializer;
+    private Config $config;
+    private Serializer $serializer;
 
-    /**
-     * @param Config $config
-     * @param Serializer $serializer
-     */
     public function __construct(Config $config, Serializer $serializer)
     {
         $this->config = $config;
@@ -60,14 +54,10 @@ class RequestFactory
             $message,
             $headers,
             $this->config->getProxyUri(),
-            $requestContext->getTimeout()
+            $requestContext->getTimeout() ?: $this->config->getTimeout()
         );
     }
 
-    /**
-     * @param RequestContext $requestContext
-     * @return HeaderCollection
-     */
     private function buildHeaders(RequestContext $requestContext): HeaderCollection
     {
         $headers = HeaderCollection::fromRequest($requestContext);

--- a/tests/Unit/Grphp/Client/Strategy/Envoy/RequestFactoryTest.php
+++ b/tests/Unit/Grphp/Client/Strategy/Envoy/RequestFactoryTest.php
@@ -17,11 +17,13 @@
  */
 declare(strict_types=1);
 
-namespace Grphp\Client\Strategy\Envoy;
+namespace Unit\Grphp\Client\Strategy\Envoy;
 
 use Grphp\Client\Config;
 use Grphp\Client\Request as RequestContext;
 use Grphp\Client\Strategy\Envoy\Config as EnvoyConfig;
+use Grphp\Client\Strategy\Envoy\Request;
+use Grphp\Client\Strategy\Envoy\RequestFactory;
 use Grphp\Protobuf\Serializer;
 use Grphp\Test\GetThingReq;
 use Grphp\Test\ThingsClient;
@@ -32,11 +34,8 @@ final class RequestFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var Config */
-    private $config;
-
-    /** @var RequestFactory */
-    private $requestFactory;
+    private Config $config;
+    private RequestFactory $requestFactory;
 
     public function buildRequest($req = null, array $metadata = [], array $options = [])
     {
@@ -65,6 +64,15 @@ final class RequestFactoryTest extends TestCase
 
         $deadlineish = intval(microtime(true) + RequestContext::DEFAULT_TIMEOUT);
         $this->assertEquals($deadlineish, intval($headers->get('Deadline')->getValuesAsString()));
+        $this->assertEquals(EnvoyConfig::DEFAULT_TIMEOUT, $httpRequest->getTimeout());
+    }
+
+    public function testBuildWithTimeout(): void
+    {
+        $requestContext = $this->buildRequest(null, [], ['timeout' => 10]);
+        $request = $this->requestFactory->build($requestContext);
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertEquals(10, $request->getTimeout());
     }
 
     public function testWithHeaders()

--- a/tests/Unit/Grphp/ClientTest.php
+++ b/tests/Unit/Grphp/ClientTest.php
@@ -21,10 +21,9 @@ use Grphp\Authentication\Basic;
 use Grphp\Client;
 use Grphp\Client\Config;
 use Grphp\Client\Error;
-use Grphp\Client\Error\Status;
+use Grphp\Client\Interceptors\Base as BaseInterceptor;
 use Grphp\Client\Response;
 use PHPUnit\Framework\TestCase;
-use Grphp\Client\Interceptors\Base as BaseInterceptor;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 final class ClientTest extends TestCase


### PR DESCRIPTION
At the moment the final timeout setting [comes from the request](https://github.com/bigcommerce/grphp/blob/338cfc5fcb68fe760d50cc6f51a75bf328b487ae/src/Grphp/Client/Strategy/Envoy/RequestExecutor.php#L164-L166), the client config timeout setting is not used. 

This PR ensures that the client config timeout setting is used when the request timeout is not set, so that requests will never go without a timeout setting. This is a bugfix but it might be behaviour changing for some setups.

Also included:
* Upgraded php-cs-fixer since my IDE kept complaining about it being outdated
* Added type hinting in a few places so we can remove unneeded phpdoc blocks.


ping @splittingred 

cc @animesh1987 @davidchin 