### PR TITLE
Add retry support with the Retry interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ Changelog for grphp.
 
 ### Pending Release
 
+### 3.5.1
+
+* Add retry support with the Retry interceptor.
+
+### 3.5.0
+
+* Add methods for mapping status code numbers to descriptive strings
+
 ### 3.4.0
 
 * Set default request timeout to the proxy client config value.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,25 @@ $client->addInterceptor($i);
 
 Interceptors run in the order that they are added, wrapping each as they go.
 
+## Retry Interceptor
+
+Retries can be enabled for given gRPC error status codes with the `Retry` interceptor. 
+```php
+use Grphp\Client\Interceptors\Retry;
+
+$client->addInterceptor(new Retry(['max_retries' => 3]));
+```
+
+The retry behaviour can be customized by passing in an array of options to the constructor. The following options are available:
+
+| Option               | Default                                                                         | Description                                                    |
+|----------------------|---------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `max_retries`        | `3`                                                                             | The maximum number of retries to attempt.                      |
+| `retry_on_statuses`  | `[Grphp\Client\Error::CODE_UNAVAILABLE]`                                        | An array of gRPC error status codes that should be retried on. |
+| `delay_milliseconds` | `200`                                                                           | The initial delay in milliseconds before a retry.              |
+| `backoff_func`       | `function (int $attempt, int $delayMilliseconds) { /* exponential backoff */ }` | A callback defining the backoff behaviour.                     |
+
+
 ## Error Handling
 
 gRPC prefers handling errors through status (BadStatus) codes; however, these do not return much information as to 

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ $client->addInterceptor(new Retry(['max_retries' => 3]));
 
 The retry behaviour can be customized by passing in an array of options to the constructor. The following options are available:
 
-| Option               | Default                                                                         | Description                                                    |
-|----------------------|---------------------------------------------------------------------------------|----------------------------------------------------------------|
-| `max_retries`        | `3`                                                                             | The maximum number of retries to attempt.                      |
-| `retry_on_statuses`  | `[Grphp\Client\Error::CODE_UNAVAILABLE]`                                        | An array of gRPC error status codes that should be retried on. |
-| `delay_milliseconds` | `200`                                                                           | The initial delay in milliseconds before a retry.              |
-| `backoff_func`       | `function (int $attempt, int $delayMilliseconds) { /* exponential backoff */ }` | A callback defining the backoff behaviour.                     |
+| Option               | Default                                                                                     | Description                                                    |
+|----------------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `max_retries`        | `3`                                                                                         | The maximum number of retries to attempt.                      |
+| `retry_on_statuses`  | `[Grphp\Client\Error::CODE_UNAVAILABLE]`                                                    | An array of gRPC error status codes that should be retried on. |
+| `delay_milliseconds` | `200`                                                                                       | The initial delay in milliseconds before a retry.              |
+| `backoff_func`       | `function (int $attempt, int $delayMilliseconds) { /* exponential backoff with jitter */ }` | A callback defining the backoff behaviour.                     |
 
 
 ## Error Handling

--- a/src/Grphp/Client/Interceptors/Retry.php
+++ b/src/Grphp/Client/Interceptors/Retry.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Grphp\Client\Interceptors;
+
+use Closure;
+use Grphp\Client\Error;
+use Grphp\Client\Error\Status;
+use Grphp\Client\Response;
+
+class Retry extends Base
+{
+    private const DEFAULT_MAX_RETRIES = 3;
+    private const DEFAULT_DELAY_MS = 200;
+
+    private int $maxRetries;
+    private int $delayMilliseconds;
+    /** @var string[] */
+    private array $retryOnStatuses;
+    private Closure $backoffFunc;
+
+    /**
+     * @param array{
+     *     max_retries: int,
+     *     delay_milliseconds: int,
+     *     retry_on_statuses: string[],
+     *     backoff_func: Closure,
+     * } $options
+     */
+    public function __construct(array $options = [])
+    {
+        parent::__construct($options);
+
+        $this->maxRetries = $options['max_retries'] ?? self::DEFAULT_MAX_RETRIES;
+        $this->delayMilliseconds = $options['delay_milliseconds'] ?? self::DEFAULT_DELAY_MS;
+        $this->retryOnStatuses = $options['retry_on_statuses'] ?? [Status::CODE_UNAVAILABLE];
+        $this->backoffFunc = $options['backoff_func'] ?? function (int $attempt, int $delayMilliseconds) {
+            usleep(pow(2, $attempt) * $delayMilliseconds * 1000);
+        };
+    }
+
+    /**
+     * @param callable $callback
+     * @return Response
+     * @throws Error
+     */
+    public function call(callable $callback): Response
+    {
+        return $this->attemptCall($callback, 0);
+    }
+
+    private function attemptCall(callable $callback, int $attempt): Response
+    {
+        try {
+            return $callback();
+        } catch (Error $e) {
+            if ($this->maxRetries > $attempt && in_array($e->getStatusCode(), $this->retryOnStatuses)) {
+                call_user_func_array($this->backoffFunc, [$attempt, $this->delayMilliseconds]);
+
+                return $this->attemptCall($callback, $attempt + 1);
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/src/Grphp/Client/Interceptors/Retry.php
+++ b/src/Grphp/Client/Interceptors/Retry.php
@@ -51,7 +51,8 @@ class Retry extends Base
         $this->delayMilliseconds = $options['delay_milliseconds'] ?? self::DEFAULT_DELAY_MS;
         $this->retryOnStatuses = $options['retry_on_statuses'] ?? [Status::CODE_UNAVAILABLE];
         $this->backoffFunc = $options['backoff_func'] ?? function (int $attempt, int $delayMilliseconds) {
-            usleep(pow(2, $attempt) * $delayMilliseconds * 1000);
+            $delay = pow(2, $attempt) * $delayMilliseconds;
+            usleep(rand((int)($delay / 2), $delay) * 1000);
         };
     }
 

--- a/tests/Unit/Grphp/Client/Interceptors/RetryTest.php
+++ b/tests/Unit/Grphp/Client/Interceptors/RetryTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Unit\Grphp\Client\Interceptors;
+
+use Grphp\Client\Config;
+use Grphp\Client\Error;
+use Grphp\Client\Interceptors\Retry;
+use Grphp\Client\Response;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class RetryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private Retry $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Retry([
+            'max_retries' => 3,
+            'delay_milliseconds' => 1,
+        ]);
+    }
+
+    public function testCallSuccessAfterRetries(): void
+    {
+        $callback = function () {
+            static $attempts = 0;
+            $attempts++;
+            if ($attempts < 2) {
+                throw new Error(
+                    new Config(),
+                    new Error\Status(14, 'test')
+                );
+            }
+
+            return $this->prophesize(Response::class)->reveal();
+        };
+
+        $this->assertInstanceOf(Response::class, $this->subject->call($callback));
+    }
+
+    public function testCallFailureAfterRetries(): void
+    {
+        $callback = function () {
+            throw new Error(new Config(), new Error\Status(14, 'test'));
+        };
+
+        $this->expectException(Error::class);
+        $this->subject->call($callback);
+    }
+
+    public function testCallFailureOnNonRetriableError(): void
+    {
+        $callback = function () {
+            throw new Error(new Config(), new Error\Status(0, 'non-retriable error'));
+        };
+
+        $this->expectException(Error::class);
+        $this->subject->call($callback);
+    }
+
+    public function testCallWithCustomBackoffFunc(): void
+    {
+        $callback = function () {
+            static $attempts = 0;
+            if ($attempts < 2) {
+                $attempts++;
+                throw new Error(
+                    new Config(),
+                    new Error\Status(14, 'test')
+                );
+            }
+
+            return $this->prophesize(Response::class)->reveal();
+        };
+
+        $backoffCalled = 0;
+
+        $this->subject = new Retry([
+            'max_retries' => 3,
+            'delay_milliseconds' => 1,
+            'backoff_func' => function (int $attempt, int $delayMilliseconds) use (&$backoffCalled) {
+                $this->assertSame(1, $delayMilliseconds);
+                $backoffCalled++;
+            },
+        ]);
+
+        $this->assertInstanceOf(Response::class, $this->subject->call($callback));
+        $this->assertSame(2, $backoffCalled);
+    }
+}


### PR DESCRIPTION
## What & why?
Does what the title says so grphp client can recover from certain errors with retries. By default it can be used to retry on `Grphp\Client\Error::CODE_UNAVAILABLE` but users can choose to add more.

## Tests
* Unit tests

ping @splittingred @filakhtov 
