### PR TITLE
Update phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,30 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php"
-         convertWarningsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertErrorsToExceptions="true"
-         backupStaticAttributes="false"
-         processIsolation="false"
-         backupGlobals="false"
-         stopOnFailure="false"
-         colors="true"
-         failOnWarning="true">
-
-    <testsuites>
-        <testsuite name="Grphp Test Suite">
-            <directory suffix="Test.php">tests/Unit</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-html" target="coverage" lowUpperBound="35" highLowerBound="70"/>
-        <log type="coverage-clover" target="coverage/coverage.xml"/>
-        <log type="junit" target="coverage/junit.xml"/>
-    </logging>
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  bootstrap="tests/bootstrap.php"
+  convertWarningsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertErrorsToExceptions="true"
+  backupStaticAttributes="false"
+  processIsolation="false"
+  backupGlobals="false"
+  stopOnFailure="false"
+  colors="true"
+  failOnWarning="true"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+  <coverage>
+    <include>
+      <directory>./src</directory>
+    </include>
+    <report>
+      <clover outputFile="coverage/coverage.xml"/>
+      <html outputDirectory="coverage" lowUpperBound="35" highLowerBound="70"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Grphp Test Suite">
+      <directory suffix="Test.php">tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="coverage/junit.xml"/>
+  </logging>
 </phpunit>


### PR DESCRIPTION
## What & Why?
We have upgraded to PHPUnit 9.x and never actually migrated the config. This resulted in the followin warning printed every time:
```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```
Migrate the configuration to the new XML schema.

ping @bigcommerce/php 