### PR TITLE
Clean-up client implementation

### DIFF
--- a/src/Grphp/Client/Interceptors/Base.php
+++ b/src/Grphp/Client/Interceptors/Base.php
@@ -53,7 +53,7 @@ abstract class Base
      * @param callable $callback
      * @return Response
      */
-    abstract public function call(callable $callback);
+    abstract public function call(callable $callback): Response;
 
     /**
      * @return Message
@@ -67,7 +67,7 @@ abstract class Base
      * @param Message $request
      * @return void
      */
-    public function setRequest(&$request)
+    public function setRequest($request): void
     {
         $this->request = $request;
     }
@@ -143,7 +143,7 @@ abstract class Base
      * @param string $method
      * @return void
      */
-    public function setMethod(string &$method): void
+    public function setMethod(string $method): void
     {
         $this->method = $method;
     }
@@ -160,7 +160,7 @@ abstract class Base
      * @param array $metadata
      * @return void
      */
-    public function setMetadata(array &$metadata = []): void
+    public function setMetadata(array $metadata = []): void
     {
         $this->metadata = $metadata;
     }
@@ -177,7 +177,7 @@ abstract class Base
      * @param array $options
      * @return void
      */
-    public function setOptions(array &$options = []): void
+    public function setOptions(array $options = []): void
     {
         $this->options = $options;
     }
@@ -203,7 +203,7 @@ abstract class Base
     /**
      * @param BaseStub $stub
      */
-    public function setStub(BaseStub &$stub)
+    public function setStub(BaseStub $stub): void
     {
         $this->stub = $stub;
     }

--- a/tests/Support/Compiled/ThingsClient.php
+++ b/tests/Support/Compiled/ThingsClient.php
@@ -17,7 +17,12 @@
  */
 namespace Grphp\Test;
 
-class ThingsClient extends \Grpc\BaseStub
+use Exception;
+use Grpc\AbstractCall;
+use Grpc\BaseStub;
+use Grpc\Channel;
+
+class ThingsClient extends BaseStub
 {
     public function getExpectedResponseMessages(): array
     {
@@ -36,36 +41,37 @@ class ThingsClient extends \Grpc\BaseStub
     /**
      * @param string $hostname hostname
      * @param array $opts channel options
-     * @param \Grpc\Channel $channel (optional) re-use channel object
-     * @throws \Exception
+     * @param Channel $channel (optional) re-use channel object
+     * @throws Exception
      */
     public function __construct($hostname, $opts, $channel = null)
     {
         parent::__construct($hostname, $opts, $channel);
-        $this->channel = new \Grpc\Channel($hostname, $opts);
+        $this->channel = new Channel($hostname, $opts);
     }
 
     /**
-     * @param \Grphp\Test\GetThingReq $argument input argument
+     * @param GetThingReq $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
      * @return StubbedCall
      */
     public function GetThing(
-        \Grphp\Test\GetThingReq $argument,
+        GetThingReq $argument,
         $metadata = [],
         $options = []
-    ) {
+    ): AbstractCall {
         $thing = new Thing();
         $thing->setId($argument->getId());
         $thing->setName('Foo');
         $resp = new GetThingResp();
         $resp->setThing($thing);
+
         return new StubbedCall(
             $resp,
             $this->channel,
             '/grphp.test.Things/GetThing',
-            ['\Grphp\Test\GetThingResp', 'decode'],
+            [GetThingResp::class, 'decode'],
             $options
         );
     }

--- a/tests/Support/TestInterceptors.php
+++ b/tests/Support/TestInterceptors.php
@@ -18,18 +18,28 @@
 namespace Grphp\Test;
 
 use Grphp\Client\Interceptors\Base;
+use Grphp\Client\Response;
 
 class TestInterceptor extends Base
 {
-    public function call(callable $callback)
+    private bool $hasBeenCalled = false;
+
+    public function call(callable $callback): Response
     {
+        $this->hasBeenCalled = true;
+
         return $callback();
+    }
+
+    public function hasBeenCalled(): bool
+    {
+        return $this->hasBeenCalled;
     }
 }
 
 class TestMetadataSetInterceptor extends Base
 {
-    public function call(callable $callback)
+    public function call(callable $callback): Response
     {
         $md = $this->getMetadata();
         $md['test'] = 'one';

--- a/tests/Unit/Grphp/Client/Interceptors/BaseTest.php
+++ b/tests/Unit/Grphp/Client/Interceptors/BaseTest.php
@@ -21,30 +21,36 @@ namespace Unit\Grphp\Client\Interceptors;
 
 use Grphp\Client\Interceptors\ResponseMessageLookupFailedException;
 use Grphp\Client\Interceptors\StubNotFoundException;
+use Grphp\Client\Response;
 use Grphp\Test\GetThingReq;
 use Grphp\Test\TestInterceptor;
 use Grphp\Test\TestMetadataSetInterceptor;
 use Grphp\Test\ThingsClient;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class BaseTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testCall(): void
     {
         $interceptor = new TestInterceptor();
-        $result = $interceptor->call(function () {
-            return 42;
-        });
-        $this->assertSame($result, 42);
+        $expectedResponse = $this->prophesize(Response::class)->reveal();
+
+        $result = $interceptor->call(fn () => $expectedResponse);
+
+        $this->assertSame($expectedResponse, $result);
     }
 
     public function testMetadata(): void
     {
         $interceptor = new TestMetadataSetInterceptor();
-        $result = $interceptor->call(function () {
-            return 1;
-        });
-        $this->assertSame($result, 1);
+
+        $expectedResponse = $this->prophesize(Response::class)->reveal();
+
+        $result = $interceptor->call(fn () => $expectedResponse);
+        $this->assertSame($expectedResponse, $result);
         $md = $interceptor->getMetadata();
         $this->assertArrayHasKey('test', $md);
         $this->assertEquals('one', $md['test']);


### PR DESCRIPTION
## What & Why?
- Use constructor property promotion where appropriate
- Add return types
- Remove pass by reference
- Simplify interceptor recursion
- Add `use` statements
- Replace `static::` with `$this->` for test assertions
- Add a test to verify interceptors are properly called

ping @bigcommerce/php 