### PR TITLE
Change Client::$config property back to protected

### DIFF
--- a/src/Grphp/Client.php
+++ b/src/Grphp/Client.php
@@ -48,7 +48,7 @@ class Client
 
     public function __construct(
         private string $clientClassName,
-        private Config $config
+        protected Config $config
     ) {
         if ($this->config->useDefaultInterceptors) {
             $this->addInterceptor(new TimerInterceptor());


### PR DESCRIPTION
## What & Why?
Previous refactoring #62, changed visibility of the `Client::$config` variable from `protected` to `private` as it isn't used anywhere outside of the class in this library. However, I have later discovered that we extend the `Client` class in the `grphp-balancer` library and it uses the `$config` property from the parent. Relax the visibility to fix this problem.

## Testing & Proof
### Before
Updated `composer.json` in the `grphp-balancer` library to use the latest master:
```
    "bigcommerce/grphp": "dev-master#6896168e5325daffab41fe6f4be4fcb25cafdf20 as 4.0"
```
Ran unit tests and discovered:
```
1) Unit\Grphp\Balancer\ClientTest::testCall with data set #0 (123, true, 0, 'Whoa now', array(array('two')))
Error: Typed property Grphp\Client::$config must not be accessed before initialization

vendor/bigcommerce/grphp/src/Grphp/Client.php:118
vendor/bigcommerce/grphp/src/Grphp/Client.php:65
src/Grphp/Balancer/Client.php:53
tests/Unit/Grphp/Balancer/ClientTest.php:53
```

### After
Updated `composer.json` in the `grphp-balancer` library to use this branch:
```
    "bigcommerce/grphp": "dev-protected-config#f34ae836cd7064baa8708537eb4c2c943c2d02ae as 4.0"
```
ran `composer update`:
```console
$ composer update
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading bigcommerce/grphp (dev-master 6896168 => dev-protected-config f34ae83)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading bigcommerce/grphp (dev-protected-config f34ae83)
  - Upgrading bigcommerce/grphp (dev-master 6896168 => dev-protected-config f34ae83): Extracting archive
Generating autoload files
48 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found
```
Ran unit tests and observed:
```
$ ./vendor/bin/phpunit 
PHPUnit 9.6.7 by Sebastian Bergmann and contributors.

Warning:       No code coverage driver available

..............                                                    14 / 14 (100%)

Time: 00:00.020, Memory: 8.00 MB

OK (14 tests, 236 assertions)
```

ping @bigcommerce/php 