### PR TITLE
Add PHP 8.4 to CircleCI matrix and fix deprecation warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     parameters:
       php-version:
         type: string
-        default: "8.0"
+        default: "8.1"
     executor:
       name: php/php
       php-version: << parameters.php-version >>
@@ -25,7 +25,7 @@ jobs:
     parameters:
       php-version:
         type: string
-        default: "8.0"
+        default: "8.1"
     executor:
       name: php/php
       php-version: << parameters.php-version >>
@@ -47,12 +47,12 @@ workflows:
           pecl_extensions: "grpc"
           matrix:
             parameters:
-              php-version: [ "8.0", "8.1", "8.2" ]
+              php-version: [ "8.1", "8.2", "8.3", "8.4" ]
       - codesniffer:
           matrix:
             parameters:
-              php-version: [ "8.0", "8.1", "8.2" ]
+              php-version: [ "8.1", "8.2", "8.3", "8.4" ]
       - cs-fixer:
           matrix:
             parameters:
-              php-version: [ "8.0", "8.1", "8.2" ]
+              php-version: [ "8.1", "8.2", "8.3" ]

--- a/src/Grphp/Client/Error/Status.php
+++ b/src/Grphp/Client/Error/Status.php
@@ -93,7 +93,7 @@ class Status
      * @param string $details
      * @param HeaderCollection $headers
      */
-    public function __construct(int $code, string $details, HeaderCollection $headers = null)
+    public function __construct(int $code, string $details, ?HeaderCollection $headers = null)
     {
         $this->code = $code;
         $this->details = $details;

--- a/src/Grphp/Client/Strategy/Envoy/RequestException.php
+++ b/src/Grphp/Client/Strategy/Envoy/RequestException.php
@@ -39,7 +39,7 @@ class RequestException extends Exception
      * @param HeaderCollection $headers
      * @param Throwable|null $previous
      */
-    public function __construct(string $body, HeaderCollection $headers, Throwable $previous = null)
+    public function __construct(string $body, HeaderCollection $headers, ?Throwable $previous = null)
     {
         $this->body = $body;
         $this->headers = $headers;

--- a/src/Grphp/Client/Strategy/H2Proxy/RequestException.php
+++ b/src/Grphp/Client/Strategy/H2Proxy/RequestException.php
@@ -38,7 +38,7 @@ class RequestException extends Exception
      * @param string $body
      * @param HeaderCollection $headers
      */
-    public function __construct(string $body, HeaderCollection $headers, Throwable $previous = null)
+    public function __construct(string $body, HeaderCollection $headers, ?Throwable $previous = null)
     {
         $this->body = $body;
         $this->headers = $headers;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,7 +16,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 $_ENV['TEST_MODE'] = 1;
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 date_default_timezone_set('UTC');
 require dirname(__DIR__) . '/tests/Support/Client.php';
 require dirname(__DIR__) . '/tests/Support/TestInterceptors.php';


### PR DESCRIPTION
Jira: [PHPMNT-177](https://bigcommercecloud.atlassian.net/browse/PHPMNT-177)

## What/Why?
- Add PHP 8.4 to CircleCI matrix
- Fix deprecation warnings
  - https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
  - https://php.watch/versions/8.4/E_STRICT-deprecated

## Rollout/Rollback
Merge / revert

## Testing
CI on this PR

[PHPMNT-177]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ