### PR TITLE
chore(platform): PHPMNT-177 Loosen google/protobuf dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,9 @@ workflows:
       - php/phpunit-tests:
           configuration: "phpunit.xml.dist"
           pecl_extensions: "grpc"
+          e:
+            name: php/php
+            php-version: <<matrix.php-version>>
           matrix:
             parameters:
               php-version: [ "8.1", "8.2", "8.3", "8.4" ]

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "description": "gRPC PHP Framework",
   "license": "MIT",
   "require": {
-    "php": "^8.0",
-    "google/protobuf": "^3.7",
+    "php": "^8.1",
+    "google/protobuf": "^3.7 || ^4.0",
     "grpc/grpc": "^1.13"
   },
   "require-dev": {


### PR DESCRIPTION
Jira: [PHPMNT-177](https://bigcommercecloud.atlassian.net/browse/PHPMNT-177)

## What/Why?
Loosen google/protobuf dependency. v3 to v4 is not a major backwards incompatible change in the PHP library. In fact, there are no changes, see https://github.com/protocolbuffers/protobuf-php/compare/v3.25.5...v4.26.0RC1

## Rollout/Rollback
Merge / revert

## Testing
CI on this PR

[PHPMNT-177]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ